### PR TITLE
Cache GET requests to OpenID providers.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,8 @@ Here's an example configuration file:
      ],
      "store": {
        "redis_url": "redis://127.0.0.1/5",
-       "expire_sessions": 900
+       "expire_sessions": 900,
+       "expire_cache": 3600
      },
      "smtp": {
        "address": "localhost:25"
@@ -73,10 +74,11 @@ in the list will be used for signing the outgoing JWTs.
 
 **store** has a ``redis_url`` value that points to a Redis database. This is
 used for ephemeral state, most importantly for tracking login attempts while
-waiting for authorization from the user. The broker itself is stateless.
-``expire_sessions`` contains the lifetime (in seconds) for sessions kept during
-login attempts. In the example, login attempts are timed out after 900s, or 15
-minutes.
+waiting for authorization from the user, and caching of identity provider
+configuration. The broker itself is stateless. ``expire_sessions`` contains the
+lifetime (in seconds) for sessions kept during login attempts. In the example,
+login attempts are timed out after 900s, or 15 minutes. ``expire_cache``
+contains the lifetime (in seconds) for the cache entries.
 
 **smtp** contains SMTP client settings, currently just the ``address``, which
 should be in the format ``<host>:<port>``.

--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,8 @@ Here's an example configuration file:
      "store": {
        "redis_url": "redis://127.0.0.1/5",
        "expire_sessions": 900,
-       "expire_cache": 3600
+       "expire_cache": 3600,
+       "max_response_size": 8096
      },
      "smtp": {
        "address": "localhost:25"
@@ -80,7 +81,8 @@ lifetime (in seconds) for sessions kept during login attempts. In the example,
 login attempts are timed out after 900s, or 15 minutes. ``expire_cache``
 contains the minimum lifetime (in seconds) for the cache entries, but
 individual entries may be kept longer if this is indicated in the HTTP headers
-providers send.
+providers send. ``max_response_size`` is the maximum allowed size (in bytes) of
+configuration documents from identity providers.
 
 **smtp** contains SMTP client settings, currently just the ``address``, which
 should be in the format ``<host>:<port>``.

--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ Here's an example configuration file:
      ],
      "store": {
        "redis_url": "redis://127.0.0.1/5",
-       "expire_keys": 900
+       "expire_sessions": 900
      },
      "smtp": {
        "address": "localhost:25"
@@ -71,11 +71,12 @@ Here's an example configuration file:
 Multiple keys can be used to implement key rotation. By default, the last key
 in the list will be used for signing the outgoing JWTs.
 
-**store** has a ``redis_url`` value that points to a Redis database. This
-is used for ephemeral state, most importantly for tracking login attempts
-while waiting for authorization from the user. The broker itself is stateless.
-``expire_keys`` contains the lifetime (in seconds) for such data. In the
-example, login attempts are timed out after 900s, or 15 minutes.
+**store** has a ``redis_url`` value that points to a Redis database. This is
+used for ephemeral state, most importantly for tracking login attempts while
+waiting for authorization from the user. The broker itself is stateless.
+``expire_sessions`` contains the lifetime (in seconds) for sessions kept during
+login attempts. In the example, login attempts are timed out after 900s, or 15
+minutes.
 
 **smtp** contains SMTP client settings, currently just the ``address``, which
 should be in the format ``<host>:<port>``.

--- a/README.rst
+++ b/README.rst
@@ -78,7 +78,9 @@ waiting for authorization from the user, and caching of identity provider
 configuration. The broker itself is stateless. ``expire_sessions`` contains the
 lifetime (in seconds) for sessions kept during login attempts. In the example,
 login attempts are timed out after 900s, or 15 minutes. ``expire_cache``
-contains the lifetime (in seconds) for the cache entries.
+contains the minimum lifetime (in seconds) for the cache entries, but
+individual entries may be kept longer if this is indicated in the HTTP headers
+providers send.
 
 **smtp** contains SMTP client settings, currently just the ``address``, which
 should be in the format ``<host>:<port>``.

--- a/src/config.rs
+++ b/src/config.rs
@@ -53,8 +53,8 @@ impl Deserialize for store::Store {
                       where D: serde::Deserializer {
         let value: Value = try!(serde::Deserialize::deserialize(de));
         let url = value.find("redis_url").unwrap().as_str().unwrap();
-        let expire_keys = value.find("expire_keys").unwrap().as_u64().unwrap() as usize;
-        let res = store::Store::new(url, expire_keys);
+        let expire_sessions = value.find("expire_sessions").unwrap().as_u64().unwrap() as usize;
+        let res = store::Store::new(url, expire_sessions);
         res.or_else(|err| Err(serde::de::Error::custom(err)))
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -53,7 +53,7 @@ impl Deserialize for store::Store {
                       where D: serde::Deserializer {
         let value: Value = try!(serde::Deserialize::deserialize(de));
         let url = value.find("redis_url").unwrap().as_str().unwrap();
-        let expire_keys = value.find("expire_keys").unwrap().as_u64().unwrap();
+        let expire_keys = value.find("expire_keys").unwrap().as_u64().unwrap() as usize;
         let res = store::Store::new(url, expire_keys);
         res.or_else(|err| Err(serde::de::Error::custom(err)))
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -54,7 +54,8 @@ impl Deserialize for store::Store {
         let value: Value = try!(serde::Deserialize::deserialize(de));
         let url = value.find("redis_url").unwrap().as_str().unwrap();
         let expire_sessions = value.find("expire_sessions").unwrap().as_u64().unwrap() as usize;
-        let res = store::Store::new(url, expire_sessions);
+        let expire_cache = value.find("expire_cache").unwrap().as_u64().unwrap() as usize;
+        let res = store::Store::new(url, expire_sessions, expire_cache);
         res.or_else(|err| Err(serde::de::Error::custom(err)))
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -55,7 +55,8 @@ impl Deserialize for store::Store {
         let url = value.find("redis_url").unwrap().as_str().unwrap();
         let expire_sessions = value.find("expire_sessions").unwrap().as_u64().unwrap() as usize;
         let expire_cache = value.find("expire_cache").unwrap().as_u64().unwrap() as usize;
-        let res = store::Store::new(url, expire_sessions, expire_cache);
+        let max_response_size = value.find("max_response_size").unwrap().as_u64().unwrap();
+        let res = store::Store::new(url, expire_sessions, expire_cache, max_response_size);
         res.or_else(|err| Err(serde::de::Error::custom(err)))
     }
 }

--- a/src/email.rs
+++ b/src/email.rs
@@ -80,12 +80,7 @@ pub fn request(app: &AppConfig, params: &QueryMap) {
 pub fn verify(app: &AppConfig, session: &str, code: &str)
               -> Result<(String, String), String> {
 
-    let res = app.store.get_session(&session);
-    if res.is_err() {
-        return Err(res.unwrap_err());
-    }
-
-    let stored = res.unwrap();
+    let stored = try!(app.store.get_session(&session));
     if code != stored.get("code").unwrap() {
         return Err("incorrect code".to_string());
     }

--- a/src/email.rs
+++ b/src/email.rs
@@ -46,8 +46,7 @@ pub fn request(app: &AppConfig, params: &QueryMap) -> Value {
     let client_id = &params.get("client_id").unwrap()[0];
     let nonce = &params.get("nonce").unwrap()[0];
     let session = session_id(&email_addr, client_id);
-    let key = format!("session:{}", session);
-    let res = app.store.store_session(&key, &[
+    let res = app.store.store_session(&session, &[
         ("email", &email_addr.to_string()),
         ("client_id", client_id),
         ("nonce", nonce),
@@ -103,8 +102,7 @@ pub fn request(app: &AppConfig, params: &QueryMap) -> Value {
 pub fn verify(app: &AppConfig, session: &str, code: &str)
               -> Result<(String, String), String> {
 
-    let key = format!("session:{}", session);
-    let res = app.store.get_session(&key);
+    let res = app.store.get_session(&session);
     if res.is_err() {
         return Err(res.unwrap_err());
     }

--- a/src/email.rs
+++ b/src/email.rs
@@ -5,11 +5,8 @@ use emailaddress::EmailAddress;
 use self::lettre::email::EmailBuilder;
 use self::lettre::transport::EmailTransport;
 use self::lettre::transport::smtp::SmtpTransportBuilder;
-use serde_json::builder::ObjectBuilder;
-use serde_json::value::Value;
 use super::{AppConfig, create_jwt};
 use super::crypto::session_id;
-use std::error::Error;
 use std::iter::Iterator;
 use url::percent_encoding::{utf8_percent_encode, QUERY_ENCODE_SET};
 use urlencoded::QueryMap;
@@ -35,7 +32,7 @@ const CODE_CHARS: &'static [char] = &[
 /// authentication, create a randomly-generated one-time pad. Then, send
 /// an email containing a link with the secret. Clicking the link will trigger
 /// the `ConfirmHandler`, returning an authentication result to the RP.
-pub fn request(app: &AppConfig, params: &QueryMap) -> Value {
+pub fn request(app: &AppConfig, params: &QueryMap) {
 
     // Generate a 6-character one-time pad.
     let email_addr = EmailAddress::new(&params.get("login_hint").unwrap()[0]).unwrap();
@@ -46,13 +43,13 @@ pub fn request(app: &AppConfig, params: &QueryMap) -> Value {
     let client_id = &params.get("client_id").unwrap()[0];
     let nonce = &params.get("nonce").unwrap()[0];
     let session = session_id(&email_addr, client_id);
-    let res = app.store.store_session(&session, &[
+    app.store.store_session(&session, &[
         ("email", &email_addr.to_string()),
         ("client_id", client_id),
         ("nonce", nonce),
         ("code", &chars),
         ("redirect", &params.get("redirect_uri").unwrap()[0]),
-    ]);
+    ]).unwrap();
 
     // Generate the URL used to verify email address ownership.
     let href = format!("{}/confirm?session={}&code={}",
@@ -71,27 +68,8 @@ pub fn request(app: &AppConfig, params: &QueryMap) -> Value {
         .build().unwrap();
     // TODO: Add support for authentication.
     let mut mailer = SmtpTransportBuilder::new(app.smtp.address.as_str()).unwrap().build();
-    let result = mailer.send(email);
+    mailer.send(email).unwrap();
     mailer.close();
-
-    // TODO: for debugging, this part returns a JSON response with some
-    // debugging stuff/diagnostics. Instead, it should return a form that
-    // allows the user to enter the code they have received.
-    let mut obj = ObjectBuilder::new();
-    if !result.is_ok() {
-        let error = result.unwrap_err();
-        obj = obj.insert("error", error.to_string());
-        obj = match error {
-            lettre::transport::error::Error::IoError(inner) => {
-                obj.insert("cause", inner.description())
-            }
-            _ => obj,
-        }
-    }
-    if !res.is_ok() {
-        obj = obj.insert("store", res.unwrap_err());
-    }
-    obj.build()
 
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,48 @@
+use std::fmt;
+use std::convert::From;
+use std::error::Error;
+use super::redis::RedisError;
+
+
+#[derive(Debug)]
+pub enum BrokerError {
+    Custom(String),
+    Redis(RedisError),
+}
+
+pub type BrokerResult<T> = Result<T, BrokerError>;
+
+impl Error for BrokerError {
+    fn description(&self) -> &str {
+        if let BrokerError::Custom(ref description) = *self {
+            description
+        } else {
+            self.cause().unwrap().description()
+        }
+    }
+
+    fn cause(&self) -> Option<&Error> {
+        match *self {
+            BrokerError::Custom(_) => None,
+            _ => Some(self)
+        }
+    }
+}
+
+impl fmt::Display for BrokerError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.description())
+    }
+}
+
+impl From<RedisError> for BrokerError {
+    fn from(err: RedisError) -> BrokerError {
+        BrokerError::Redis(err)
+    }
+}
+
+impl From<BrokerError> for String {
+    fn from(err: BrokerError) -> String {
+        err.description().to_string()
+    }
+}

--- a/src/lib.rs.in
+++ b/src/lib.rs.in
@@ -22,6 +22,7 @@ use std::io::{BufReader, Read};
 use time::now_utc;
 use urlencoded::{UrlEncodedBody, UrlEncodedQuery};
 
+pub mod error;
 pub mod config;
 pub use config::AppConfig;
 pub mod crypto;

--- a/src/lib.rs.in
+++ b/src/lib.rs.in
@@ -150,10 +150,9 @@ impl Handler for AuthHandler {
 
         } else {
 
-            // Email loop authentication. For now, returns a JSON response;
-            // empty if successful, otherwise contains an error.
-            let obj = email::request(&self.app, params);
-            json_response(&obj)
+            // Email loop authentication. For now, returns 204.
+            // TODO: Return a form that allows the user to enter the code.
+            Ok(Response::with((status::NoContent)))
 
         }
     }

--- a/src/lib.rs.in
+++ b/src/lib.rs.in
@@ -1,6 +1,7 @@
 extern crate emailaddress;
 #[macro_use]
 extern crate log;
+extern crate hyper;
 extern crate iron;
 extern crate redis;
 extern crate serde_json;
@@ -29,6 +30,7 @@ pub mod crypto;
 pub mod email;
 pub mod oidc;
 pub mod store;
+pub mod store_cache;
 
 
 /// Helper function for returning an Iron response with JSON data.

--- a/src/oidc.rs
+++ b/src/oidc.rs
@@ -33,8 +33,7 @@ pub fn request(app: &AppConfig, params: &QueryMap) -> Url {
 
     // Store the nonce and the RP's `redirect_uri` in Redis for use in the
     // callback handler.
-    let key = format!("session:{}", session);
-    let _ = app.store.store_session(&key, &[
+    let _ = app.store.store_session(&session, &[
         ("email", &email_addr.to_string()),
         ("client_id", client_id),
         ("nonce", nonce),
@@ -79,12 +78,11 @@ pub fn request(app: &AppConfig, params: &QueryMap) -> Url {
 /// Match the returned email address and nonce against our Redis data, then
 /// extract the identity token returned by the provider and verify it. Return
 /// an identity token for the RP if successful, or an error message otherwise.
-pub fn verify(app: &AppConfig, session_id: &str, code: &str)
+pub fn verify(app: &AppConfig, session: &str, code: &str)
               -> Result<(String, String), String> {
 
     // Validate that the callback matches an auth request in Redis.
-    let key = format!("session:{}", session_id);
-    let res = app.store.get_session(&key);
+    let res = app.store.get_session(&session);
     if res.is_err() {
         return Err(res.unwrap_err());
     }

--- a/src/oidc.rs
+++ b/src/oidc.rs
@@ -82,12 +82,7 @@ pub fn verify(app: &AppConfig, session: &str, code: &str)
               -> Result<(String, String), String> {
 
     // Validate that the callback matches an auth request in Redis.
-    let res = app.store.get_session(&session);
-    if res.is_err() {
-        return Err(res.unwrap_err());
-    }
-
-    let stored = res.unwrap();
+    let stored = try!(app.store.get_session(&session));
     let email_addr = EmailAddress::new(stored.get("email").unwrap()).unwrap();
     let origin = stored.get("client_id").unwrap();
     let nonce = stored.get("nonce").unwrap();

--- a/src/store.rs
+++ b/src/store.rs
@@ -10,10 +10,11 @@ pub struct Store {
     pub cache: StoreCache,
     pub expire_sessions: usize, // TTL of session keys, in seconds
     pub expire_cache: usize, // TTL of cache keys, in seconds
+    pub max_response_size: u64, // Maximum size of HTTP GET responses
 }
 
 impl Store {
-    pub fn new(url: &str, expire_sessions: usize, expire_cache: usize)
+    pub fn new(url: &str, expire_sessions: usize, expire_cache: usize, max_response_size: u64)
                -> Result<Store, &'static str> {
         let res = redis::Client::open(url);
         if res.is_err() {
@@ -24,6 +25,7 @@ impl Store {
             cache: StoreCache,
             expire_sessions: expire_sessions,
             expire_cache: expire_cache,
+            max_response_size: max_response_size,
         })
     }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -1,21 +1,30 @@
 use std::collections::HashMap;
 use super::error::{BrokerResult, BrokerError};
 use super::redis::{self, Commands, PipelineCommands};
+use super::store_cache::StoreCache;
 
 
 #[derive(Clone)]
 pub struct Store {
     pub client: redis::Client,
+    pub cache: StoreCache,
     pub expire_sessions: usize, // TTL of session keys, in seconds
+    pub expire_cache: usize, // TTL of cache keys, in seconds
 }
 
 impl Store {
-    pub fn new(url: &str, expire_sessions: usize) -> Result<Store, &'static str> {
+    pub fn new(url: &str, expire_sessions: usize, expire_cache: usize)
+               -> Result<Store, &'static str> {
         let res = redis::Client::open(url);
         if res.is_err() {
             return Err("error opening store connection");
         }
-        Ok(Store { client: res.unwrap(), expire_sessions: expire_sessions })
+        Ok(Store {
+            client: res.unwrap(),
+            cache: StoreCache,
+            expire_sessions: expire_sessions,
+            expire_cache: expire_cache,
+        })
     }
 
     pub fn store_session(&self, session_id: &str, data: &[(&str, &str)])

--- a/src/store.rs
+++ b/src/store.rs
@@ -6,11 +6,11 @@ use super::redis::{self, Commands, PipelineCommands};
 #[derive(Clone)]
 pub struct Store {
     pub client: redis::Client,
-    pub expire_keys: u64, // Redis key TTL, in seconds
+    pub expire_keys: usize, // Redis key TTL, in seconds
 }
 
 impl Store {
-    pub fn new(url: &str, expire_keys: u64) -> Result<Store, &'static str> {
+    pub fn new(url: &str, expire_keys: usize) -> Result<Store, &'static str> {
         let res = redis::Client::open(url);
         if res.is_err() {
             return Err("error opening store connection");
@@ -24,7 +24,7 @@ impl Store {
         try!(redis::pipe()
                 .atomic()
                 .hset_multiple(&key, data).ignore()
-                .expire(&key, self.expire_keys as usize).ignore()
+                .expire(&key, self.expire_keys).ignore()
                 .query(&self.client));
         Ok(())
     }

--- a/src/store_cache.rs
+++ b/src/store_cache.rs
@@ -1,0 +1,57 @@
+use std::io::Read;
+use super::hyper::client::Client as HttpClient;
+use super::redis::Commands;
+use super::error::BrokerResult;
+use super::store::Store;
+
+
+/// Represents a Redis key.
+pub enum CacheKey<'a> {
+    Discovery { domain: &'a str },
+    KeySet { domain: &'a str },
+}
+
+impl<'a> CacheKey<'a> {
+    fn to_string(&self) -> String {
+        match *self {
+            CacheKey::Discovery { domain } => {
+                format!("cache:discovery:{}", domain)
+            },
+            CacheKey::KeySet { domain } => {
+                format!("cache:key-set:{}", domain)
+            }
+        }
+    }
+}
+
+
+#[derive(Clone)]
+pub struct StoreCache;
+
+impl StoreCache {
+    /// Fetch `url` from cache or using a HTTP GET request. The cache is stored in `store` with
+    /// `key`. The `session` is used to make the HTTP GET request, if necessary.
+    pub fn fetch_url(&self, store: &Store, key: CacheKey, session: &HttpClient, url: &str)
+                     -> BrokerResult<String> {
+
+        // Try to retrieve the result from cache.
+        let key_str = key.to_string();
+        let stored: Option<String> = try!(store.client.get(&key_str));
+        stored.map_or_else(|| {
+
+            // Cache miss, make a request.
+            let mut rsp = try!(session.get(url).send());
+            let mut data = String::new();
+            try!(rsp.read_to_string(&mut data));
+
+            // Cache the response for `expire_cache`.
+            try!(store.client.set_ex(&key_str, &data, store.expire_cache));
+
+            Ok(data)
+
+        }, |data| {
+            Ok(data)
+        })
+
+    }
+}

--- a/test.json
+++ b/test.json
@@ -5,7 +5,7 @@
   ],
   "store": {
     "redis_url": "redis://127.0.0.1/5",
-    "expire_keys": 900
+    "expire_sessions": 900
   },
   "sender": {
     "name": "Portier",

--- a/test.json
+++ b/test.json
@@ -5,7 +5,8 @@
   ],
   "store": {
     "redis_url": "redis://127.0.0.1/5",
-    "expire_sessions": 900
+    "expire_sessions": 900,
+    "expire_cache": 3600
   },
   "sender": {
     "name": "Portier",

--- a/test.json
+++ b/test.json
@@ -6,7 +6,8 @@
   "store": {
     "redis_url": "redis://127.0.0.1/5",
     "expire_sessions": 900,
-    "expire_cache": 3600
+    "expire_cache": 3600,
+    "max_response_size": 8096
   },
   "sender": {
     "name": "Portier",


### PR DESCRIPTION
Fixes #6 and #7.

Note that these are still babysteps in Rust for me. Beside that, some things I'm considering:

 - Maybe we should have `fetch_json_cached` be a store method. Seems like a slightly better place to handle this sort of thing than in oidc.

 - Minimum cache age is now not configurable. Simplest would be using `expire_keys`, but it seems weird to tie it to session lifespan. I'm itching to rename `expire_keys`, actually, and then we can have `session_age`, `min_cache_age`, and `max_cache_size` in the future. But I'm not sure what our view is on breaking changes?