### PR TITLE
Handle run-time errors

### DIFF
--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -158,8 +158,9 @@ pub fn verify_jws(jws: &str, key_set: &Value) -> Result<Value, ()> {
     let pub_key = try!(jwk_key_set_find(key_set, kid));
 
     // Verify the identity token's signature.
-    let message = format!("{}.{}", parts[0], parts[1]);
-    let sha256 = hash::hash(hash::Type::SHA256, message.as_bytes());
+    let message_len = parts[0].len() + parts[1].len() + 1;
+    let bytes = &jws[..message_len].as_bytes();
+    let sha256 = hash::hash(hash::Type::SHA256, bytes);
     if !pub_key.verify(&sha256, &decoded[2]) {
         return Err(());
     }

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -104,10 +104,13 @@ pub fn session_id(email: &EmailAddress, client_id: &str) -> String {
 /// Searches the provided JWK Key Set Value for the key matching the given
 /// id. Returns a usable public key if exactly one key is found.
 pub fn jwk_key_set_find(set: &Value, kid: &str) -> Result<PKey, ()> {
-    let matching = set.find("keys").unwrap().as_array().unwrap().iter()
+    let key_objs = try!(
+        set.find("keys").and_then(|v| v.as_array()).ok_or(())
+    );
+    let matching = key_objs.iter()
         .filter(|key_obj| {
-            key_obj.find("kid").unwrap().as_str().unwrap() == kid &&
-            key_obj.find("use").unwrap().as_str().unwrap() == "sig"
+            key_obj.find("kid").and_then(|v| v.as_str()) == Some(kid) &&
+            key_obj.find("use").and_then(|v| v.as_str()) == Some("sig")
         })
         .collect::<Vec<&Value>>();
 
@@ -117,12 +120,19 @@ pub fn jwk_key_set_find(set: &Value, kid: &str) -> Result<PKey, ()> {
     }
 
     // Then, use the data to build a public key object for verification.
-    let n_b64 = matching[0].find("n").unwrap().as_str().unwrap();
-    let e_b64 = matching[0].find("e").unwrap().as_str().unwrap();
-    let n = BigNum::new_from_slice(&n_b64.from_base64().unwrap()).unwrap();
-    let e = BigNum::new_from_slice(&e_b64.from_base64().unwrap()).unwrap();
+    let n = try!(
+        matching[0].find("n").and_then(|v| v.as_str()).ok_or(())
+            .and_then(|data| data.from_base64().map_err(|_| ()))
+            .and_then(|data| BigNum::new_from_slice(&data).map_err(|_| ()))
+    );
+    let e = try!(
+        matching[0].find("e").and_then(|v| v.as_str()).ok_or(())
+            .and_then(|data| data.from_base64().map_err(|_| ()))
+            .and_then(|data| BigNum::new_from_slice(&data).map_err(|_| ()))
+    );
+    let rsa = try!(RSA::from_public_components(n, e).map_err(|_| ()));
     let mut pub_key = PKey::new();
-    pub_key.set_rsa(&RSA::from_public_components(n, e).unwrap());
+    pub_key.set_rsa(&rsa);
     Ok(pub_key)
 }
 
@@ -132,17 +142,28 @@ pub fn verify_jws(jws: &str, key_set: &Value) -> Result<Value, ()> {
     // Extract the header from the JWT structure. Determine what key was used
     // to sign the token, so we can then verify the signature.
     let parts: Vec<&str> = jws.split('.').collect();
-    let jwt_header: Value = from_slice(&parts[0].from_base64().unwrap()).unwrap();
-    let kid = jwt_header.find("kid").unwrap().as_str().unwrap();
+    if parts.len() != 3 {
+        return Err(());
+    }
+    let decoded = try!(
+        parts.iter().map(|s| s.from_base64())
+            .collect::<Result<Vec<_>, _>>().map_err(|_| ())
+    );
+    let jwt_header: Value = try!(
+        from_slice(&decoded[0]).map_err(|_| ())
+    );
+    let kid = try!(
+        jwt_header.find("kid").and_then(|v| v.as_str()).ok_or(())
+    );
     let pub_key = try!(jwk_key_set_find(key_set, kid));
 
     // Verify the identity token's signature.
     let message = format!("{}.{}", parts[0], parts[1]);
     let sha256 = hash::hash(hash::Type::SHA256, message.as_bytes());
-    let sig = parts[2].from_base64().unwrap();
-    if !pub_key.verify(&sha256, &sig) {
+    if !pub_key.verify(&sha256, &decoded[2]) {
         return Err(());
     }
 
-    Ok(from_slice(&parts[1].from_base64().unwrap()).unwrap())
+    let payload = try!(from_slice(&decoded[1]).map_err(|_| ()));
+    Ok(payload)
 }

--- a/src/email.rs
+++ b/src/email.rs
@@ -78,15 +78,15 @@ pub fn verify(app: &AppConfig, session: &str, code: &str)
               -> Result<(String, String), String> {
 
     let stored = try!(app.store.get_session(&session));
-    if code != stored.get("code").unwrap() {
+    if code != &stored["code"] {
         return Err("incorrect code".to_string());
     }
 
-    let email = stored.get("email").unwrap();
-    let client_id = stored.get("client_id").unwrap();
-    let nonce = stored.get("nonce").unwrap();
+    let email = &stored["email"];
+    let client_id = &stored["client_id"];
+    let nonce = &stored["nonce"];
     let id_token = create_jwt(app, email, client_id, nonce);
-    let redirect = stored.get("redirect").unwrap().to_string();
-    Ok((id_token, redirect))
+    let redirect = &stored["redirect"];
+    Ok((id_token, redirect.to_string()))
 
 }

--- a/src/email.rs
+++ b/src/email.rs
@@ -54,8 +54,8 @@ pub fn request(app: &AppConfig, email_addr: EmailAddress, client_id: &str, nonce
                        utf8_percent_encode(&session, QUERY_ENCODE_SET),
                        utf8_percent_encode(&chars, QUERY_ENCODE_SET));
 
-    // Generate a simple email and send it through the SMTP server running
-    // on localhost. TODO: Use templates for the email message.
+    // Generate a simple email and send it through the SMTP server.
+    // TODO: Use templates for the email message.
     let email = EmailBuilder::new()
         .to(email_addr.to_string().as_str())
         .from((&*app.sender.address, &*app.sender.name))

--- a/src/email.rs
+++ b/src/email.rs
@@ -42,6 +42,7 @@ pub fn request(app: &AppConfig, email_addr: EmailAddress, client_id: &str, nonce
     // Store data for this request in Redis, to reference when user uses
     // the generated link.
     try!(app.store.store_session(&session, &[
+        ("type", "email"),
         ("email", &email_addr.to_string()),
         ("client_id", client_id),
         ("nonce", nonce),
@@ -83,6 +84,9 @@ pub fn verify(app: &AppConfig, session: &str, code: &str)
               -> BrokerResult<(String, String)> {
 
     let stored = try!(app.store.get_session(&session));
+    if &stored["type"] != "email" {
+        return Err(BrokerError::Custom("invalid session".to_string()));
+    }
     if code != &stored["code"] {
         return Err(BrokerError::Custom("incorrect code".to_string()));
     }

--- a/src/email.rs
+++ b/src/email.rs
@@ -1,7 +1,7 @@
 extern crate rand;
 
 use emailaddress::EmailAddress;
-use super::error::BrokerResult;
+use super::error::{BrokerError, BrokerResult};
 use super::lettre::email::EmailBuilder;
 use super::lettre::transport::EmailTransport;
 use super::lettre::transport::smtp::SmtpTransportBuilder;
@@ -80,11 +80,11 @@ pub fn request(app: &AppConfig, email_addr: EmailAddress, client_id: &str, nonce
 /// Checks that the session exists and matches the one-time pad. If so,
 /// returns the Identity Token; otherwise, returns an error message.
 pub fn verify(app: &AppConfig, session: &str, code: &str)
-              -> Result<(String, String), String> {
+              -> BrokerResult<(String, String)> {
 
     let stored = try!(app.store.get_session(&session));
     if code != &stored["code"] {
-        return Err("incorrect code".to_string());
+        return Err(BrokerError::Custom("incorrect code".to_string()));
     }
 
     let email = &stored["email"];

--- a/src/email.rs
+++ b/src/email.rs
@@ -85,10 +85,10 @@ pub fn verify(app: &AppConfig, session: &str, code: &str)
 
     let stored = try!(app.store.get_session(&session));
     if &stored["type"] != "email" {
-        return Err(BrokerError::Custom("invalid session".to_string()));
+        return Err(BrokerError::Input("invalid session".to_string()));
     }
     if code != &stored["code"] {
-        return Err(BrokerError::Custom("incorrect code".to_string()));
+        return Err(BrokerError::Input("incorrect code".to_string()));
     }
 
     let email = &stored["email"];

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,6 +4,7 @@ use std::error::Error;
 use std::io::Error as IoError;
 use super::hyper::Error as HttpError;
 use super::redis::RedisError;
+use super::lettre::transport::error::Error as MailError;
 use super::iron::IronError;
 use super::iron::status;
 
@@ -15,6 +16,7 @@ pub enum BrokerError {
     Io(IoError),
     Redis(RedisError),
     Http(HttpError),
+    Mail(MailError),
 }
 
 pub type BrokerResult<T> = Result<T, BrokerError>;
@@ -70,3 +72,4 @@ macro_rules! from_error {
 from_error!(IoError, Io);
 from_error!(HttpError, Http);
 from_error!(RedisError, Redis);
+from_error!(MailError, Mail);

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,6 +4,8 @@ use std::error::Error;
 use std::io::Error as IoError;
 use super::hyper::Error as HttpError;
 use super::redis::RedisError;
+use super::iron::IronError;
+use super::iron::status;
 
 
 /// Union of all possible runtime error types.
@@ -43,6 +45,13 @@ impl fmt::Display for BrokerError {
 impl From<BrokerError> for String {
     fn from(err: BrokerError) -> String {
         err.description().to_string()
+    }
+}
+
+// TODO: Add a category for user errors, and return such errors to the RP.
+impl From<BrokerError> for IronError {
+    fn from(err: BrokerError) -> IronError {
+        IronError::new(err, status::ServiceUnavailable)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ extern crate emailaddress;
 extern crate log;
 extern crate hyper;
 extern crate iron;
+extern crate lettre;
 extern crate redis;
 extern crate serde;
 extern crate serde_json;
@@ -213,7 +214,7 @@ broker_handler!(AuthHandler, |app, req| {
 
         // Email loop authentication. For now, returns 204.
         // TODO: Return a form that allows the user to enter the code.
-        email::request(app, email_addr, client_id, nonce, redirect_uri);
+        try!(email::request(app, email_addr, client_id, nonce, redirect_uri));
         Ok(Response::with((status::NoContent)))
 
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,19 +164,22 @@ broker_handler!(AuthHandler, |app, req| {
         }
     );
     let email_addr = EmailAddress::new(&params.get("login_hint").unwrap()[0]).unwrap();
+    let client_id = &params.get("client_id").unwrap()[0];
+    let nonce = &params.get("nonce").unwrap()[0];
+    let redirect_uri = &params.get("redirect_uri").unwrap()[0];
     if app.providers.contains_key(&email_addr.domain) {
 
         // OIDC authentication. Using 302 Found for redirection here. Note
         // that, per RFC 7231, a user agent MAY change the request method
         // from POST to GET for the subsequent request.
-        let auth_url = oidc::request(app, params);
+        let auth_url = oidc::request(app, email_addr, client_id, nonce, redirect_uri);
         Ok(Response::with((status::Found, modifiers::Redirect(auth_url))))
 
     } else {
 
         // Email loop authentication. For now, returns 204.
         // TODO: Return a form that allows the user to enter the code.
-        email::request(app, params);
+        email::request(app, email_addr, client_id, nonce, redirect_uri);
         Ok(Response::with((status::NoContent)))
 
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,7 +204,9 @@ broker_handler!(AuthHandler, |app, req| {
         // OIDC authentication. Using 302 Found for redirection here. Note
         // that, per RFC 7231, a user agent MAY change the request method
         // from POST to GET for the subsequent request.
-        let auth_url = oidc::request(app, email_addr, client_id, nonce, redirect_uri);
+        let auth_url = try!(
+            oidc::request(app, email_addr, client_id, nonce, redirect_uri)
+        );
         Ok(Response::with((status::Found, modifiers::Redirect(auth_url))))
 
     } else {

--- a/src/oidc.rs
+++ b/src/oidc.rs
@@ -130,9 +130,9 @@ pub fn verify(app: &AppConfig, session: &str, code: &str)
 
     // Validate that the callback matches an auth request in Redis.
     let stored = try!(app.store.get_session(&session));
-    let email_addr = EmailAddress::new(stored.get("email").unwrap()).unwrap();
-    let origin = stored.get("client_id").unwrap();
-    let nonce = stored.get("nonce").unwrap();
+    let email_addr = EmailAddress::new(&stored["email"]).unwrap();
+    let origin = &stored["client_id"];
+    let nonce = &stored["nonce"];
 
     let client = HttpClient::new();
 
@@ -140,7 +140,8 @@ pub fn verify(app: &AppConfig, session: &str, code: &str)
     // `token_endpoint` and `jwks_uri` values from it. TODO: save these
     // when requesting the Discovery document in the `oauth_request()`
     // function, and/or cache them by provider host.
-    let provider = &app.providers[&email_addr.domain];
+    let domain = &email_addr.domain;
+    let provider = &app.providers[domain];
     let val: Value = {
         let data = app.store.cache.fetch_url(
             &app.store,
@@ -208,7 +209,7 @@ pub fn verify(app: &AppConfig, session: &str, code: &str)
     // If everything is okay, build a new identity token and send it
     // to the relying party.
     let id_token = create_jwt(app, &email_addr.to_string(), origin, nonce);
-    let redirect = stored.get("redirect").unwrap();
+    let redirect = &stored["redirect"];
     Ok((id_token, redirect.to_string()))
 
 }

--- a/src/oidc.rs
+++ b/src/oidc.rs
@@ -126,7 +126,7 @@ pub fn canonicalized(email: &str) -> String {
 /// extract the identity token returned by the provider and verify it. Return
 /// an identity token for the RP if successful, or an error message otherwise.
 pub fn verify(app: &AppConfig, session: &str, code: &str)
-              -> Result<(String, String), String> {
+              -> BrokerResult<(String, String)> {
 
     // Validate that the callback matches an auth request in Redis.
     let stored = try!(app.store.get_session(&session));

--- a/src/oidc.rs
+++ b/src/oidc.rs
@@ -10,7 +10,6 @@ use super::crypto::{session_id, verify_jws};
 use super::store_cache::CacheKey;
 use time::now_utc;
 use url::percent_encoding::{utf8_percent_encode, QUERY_ENCODE_SET};
-use urlencoded::QueryMap;
 
 
 /// Helper method to issue an OAuth authorization request.
@@ -23,11 +22,8 @@ use urlencoded::QueryMap;
 /// user will be redirected back to after confirming (or denying) the
 /// Authentication Request. Included in the request is a nonce which we can
 /// later use to definitively match the callback to this request.
-pub fn request(app: &AppConfig, params: &QueryMap) -> Url {
+pub fn request(app: &AppConfig, email_addr: EmailAddress, client_id: &str, nonce: &str, redirect_uri: &str) -> Url {
 
-    let email_addr = EmailAddress::new(&params.get("login_hint").unwrap()[0]).unwrap();
-    let client_id = &params.get("client_id").unwrap()[0];
-    let nonce = &params.get("nonce").unwrap()[0];
     let session = session_id(&email_addr, client_id);
 
     // Store the nonce and the RP's `redirect_uri` in Redis for use in the
@@ -36,7 +32,7 @@ pub fn request(app: &AppConfig, params: &QueryMap) -> Url {
         ("email", &email_addr.to_string()),
         ("client_id", client_id),
         ("nonce", nonce),
-        ("redirect", &params.get("redirect_uri").unwrap()[0]),
+        ("redirect", redirect_uri),
     ]).unwrap();
 
     let client = HttpClient::new();

--- a/src/oidc.rs
+++ b/src/oidc.rs
@@ -39,9 +39,6 @@ pub fn request(app: &AppConfig, email_addr: EmailAddress, client_id: &str, nonce
 
     // Retrieve the provider's Discovery document and extract the
     // `authorization_endpoint` from it.
-    // TODO: cache other data for use in the callback handler, so that we
-    // don't have to request the Discovery document twice. We could even store
-    // per-provider data in Redis so we can amortize the cost of discovery.
     let provider = &app.providers[&email_addr.domain];
     let val: Value = {
         let data = app.store.cache.fetch_url(

--- a/src/store.rs
+++ b/src/store.rs
@@ -45,7 +45,7 @@ impl Store {
         let key = Self::format_session_key(session_id);
         let stored: HashMap<String, String> = try!(self.client.hgetall(&key));
         if stored.is_empty() {
-            return Err(BrokerError::Custom("session not found".to_string()));
+            return Err(BrokerError::Input("session not found".to_string()));
         }
         Ok(stored)
     }

--- a/src/store_cache.rs
+++ b/src/store_cache.rs
@@ -8,6 +8,8 @@ use super::hyper::header::{
 use super::redis::Commands;
 use super::error::{BrokerError, BrokerResult};
 use super::store::Store;
+use serde_json::de::from_str;
+use serde_json::value::Value;
 
 
 /// Represents a Redis key.
@@ -75,5 +77,15 @@ impl StoreCache {
             Ok(data)
         })
 
+    }
+
+    /// Similar to `fetch_url`, but also parses the response as JSON.
+    pub fn fetch_json_url(&self, store: &Store, key: CacheKey, session: &HttpClient, url: &str)
+                          -> BrokerResult<Value> {
+        self.fetch_url(store, key, session, url).and_then(|data| {
+            from_str(&data).map_err(|_| {
+                BrokerError::Custom("response is not valid JSON".to_string())
+            })
+        })
     }
 }


### PR DESCRIPTION
This PR adds error handling to all runtime situations where errors can be raised. The remaining unwraps are either possible startup failures, or cases where we always expect success given in those conditions / given a correct environment.

I've added a TODO for categorising errors that we should report back to the user. Right now, errors are either propagated from libs or `BrokerError::Custom`, and these all result in a log entry and a 503 to the user. The exception is missing request parameters, which send a 400 with a description.

I'll continue working on proper notification to the user, but created this PR so that I can get some review up to this point, as the changes are already quite substantial. (But hopefully the commits are clear steps.) IMHO, we can also merge up to this point; it is a complete working change as is.