### PR TITLE
Add a script to build Docker images.

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# This script builds the portier/broker Docker image. The image contains a
+# static release build of portier-broker, and a bundle of root certificates
+# extracted from Debian.
+set -xe
+cd "$(dirname "${0}")/"
+
+SOURCE_DIR="${PWD}"
+TARGET_DIR="target/x86_64-unknown-linux-musl/release"
+DOCKER_SOCK="/var/run/docker.sock"
+
+docker run --rm \
+    -v "${SOURCE_DIR}":/src -w /src \
+    clux/muslrust cargo build --release
+
+container="$(
+    docker create \
+        -v "${DOCKER_SOCK}":"${DOCKER_SOCK}":ro \
+        -i docker /bin/sh -xes
+)"
+trap "docker rm -f ${container}" exit
+
+docker cp "${TARGET_DIR}/portier-broker" "${container}:/"
+docker start -ai "${container}" << END_CONTAINER_SCRIPT
+
+mkdir /tmp/build
+cd /tmp/build
+mv /portier-broker ./
+
+mkdir certs
+cd certs
+cp -L /usr/share/ca-certificates/mozilla/*.crt .
+c_rehash .
+cat *.crt > ca-certificates.crt
+cd ..
+
+tee Dockerfile > /dev/null << EOF
+FROM scratch
+
+COPY ./certs /certs
+ENV SSL_CERT_FILE=/certs/ca-certificates.crt \
+    SSL_CERT_DIR=/certs
+
+COPY ./portier-broker /
+USER 65534:65534
+ENTRYPOINT ["/portier-broker"]
+CMD ["/cfg/config.json"]
+EXPOSE 3333
+EOF
+docker build -t portier/broker .
+
+END_CONTAINER_SCRIPT


### PR DESCRIPTION
Using this script, I've pushed a first experimental image to [portier/broker](https://hub.docker.com/r/portier/broker/). The image is ~3MB compressed, and ~7MB extracted on disk.

I've tested that the oidc flow is able to communicatie over HTTPS with Google.

If we merge this, I can for now configure a private Jenkins instance to poll `master` every 15 minutes and build images. (The current image was also produced on this Jenkins instance.)