### PR TITLE
Allow setting SMTP credentials.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,6 +54,8 @@ Here's an example configuration file:
 
     [smtp]
     address = "localhost:25"
+    username = "johndoe"
+    password = "supersecret"
 
     [sender]
     name = "Portier"
@@ -87,8 +89,9 @@ individual entries may be kept longer if this is indicated in the HTTP headers
 providers send. ``max_response_size`` is the maximum allowed size (in bytes) of
 configuration documents from identity providers.
 
-**smtp** contains SMTP client settings, currently just the ``address``, which
-should be in the format ``<host>:<port>``.
+**smtp** contains SMTP client settings, most importantly the ``address``, which
+should be in the format ``<host>:<port>``. The ``username`` and ``password``
+fields are optional, and may be set to provide login credentials.
 
 **sender** is the sender information used when sending email for the email
 loop authentication. It requires ``name`` and ``address`` keys.

--- a/config.toml.dist
+++ b/config.toml.dist
@@ -15,6 +15,8 @@ max_response_size = 8096
 
 [smtp]
 address = "localhost:25"
+username = "johndoe"
+password = "supersecret"
 
 [sender]
 name = "Portier"

--- a/src/email.rs
+++ b/src/email.rs
@@ -75,10 +75,11 @@ pub fn request(app: &AppConfig, email_addr: EmailAddress, client_id: &str, nonce
                      &app.templates.email_text.render(params))
         .subject(&format!("Finish logging in to {}", client_id))
         .build().unwrap();
-    // TODO: Add support for authentication.
-    let mut mailer = try!(
-        SmtpTransportBuilder::new(app.smtp.address.as_str())
-    ).build();
+    let mut builder = try!(SmtpTransportBuilder::new(app.smtp.address.as_str()));
+    if let (&Some(ref username), &Some(ref password)) = (&app.smtp.username, &app.smtp.password) {
+        builder = builder.credentials(username, password);
+    }
+    let mut mailer = builder.build();
     try!(mailer.send(email));
     mailer.close();
     Ok(session)

--- a/src/serde_types.in.rs
+++ b/src/serde_types.in.rs
@@ -4,12 +4,11 @@
 
 
 // Newtype so we can implement Deserialize for templates.
-#[derive(Clone)]
 pub struct Template(mustache::Template);
 
 
-/// Represents an email address.
-#[derive(Clone, Deserialize)]
+/// Contains the SMTP server connection settings.
+#[derive(Deserialize)]
 pub struct Smtp {
     pub address: String,
     pub username: Option<String>,
@@ -18,7 +17,7 @@ pub struct Smtp {
 
 
 /// Represents an email address.
-#[derive(Clone, Deserialize)]
+#[derive(Deserialize)]
 pub struct Email {
     pub address: String,
     pub name: String,
@@ -26,7 +25,7 @@ pub struct Email {
 
 
 /// Represents an OpenID Connect provider.
-#[derive(Clone, Deserialize)]
+#[derive(Deserialize)]
 pub struct Provider {
     pub discovery: String,
     pub client_id: String,
@@ -36,7 +35,6 @@ pub struct Provider {
 
 
 // Contains all templates we use in compiled form.
-#[derive(Clone)]
 pub struct Templates {
     /// Page displayed when the confirmation email was sent.
     pub confirm_email: Template,
@@ -52,7 +50,7 @@ pub struct Templates {
 
 
 /// Holds runtime configuration data for this daemon instance.
-#[derive(Clone, Deserialize)]
+#[derive(Deserialize)]
 pub struct AppConfig {
     /// Address to listen on
     pub listen_ip: String,

--- a/src/serde_types.in.rs
+++ b/src/serde_types.in.rs
@@ -11,7 +11,9 @@ pub struct Template(mustache::Template);
 /// Represents an email address.
 #[derive(Clone, Deserialize)]
 pub struct Smtp {
-    pub address: String
+    pub address: String,
+    pub username: Option<String>,
+    pub password: Option<String>,
 }
 
 


### PR DESCRIPTION
Part of #43. The other part I want to implement is the TLS security level, but that depends on a lettre patch.

I've verified this works at least with Amazon SES.