### PR TITLE
Optional whitelist of clients.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,13 +51,14 @@ are:
 
 **[server] section:**
 
-============== ==================== ===========
-``config.ini`` Environment Variable Default
-============== ==================== ===========
-listen_ip      BROKER_IP            "127.0.0.1"
-listen_port    BROKER_PORT          3333
-public_url     BROKER_PUBLIC_URL    (none)
-============== ==================== ===========
+=============== ====================== =====================
+``config.ini``  Environment Variable   Default
+=============== ====================== =====================
+listen_ip       BROKER_IP              "127.0.0.1"
+listen_port     BROKER_PORT            3333
+public_url      BROKER_PUBLIC_URL      (none)
+allowed_origins BROKER_ALLOWED_ORIGINS (none) (unrestricted)
+=============== ====================== =====================
 
 **[crypto] section:**
 

--- a/config.toml.dist
+++ b/config.toml.dist
@@ -5,6 +5,8 @@ listen_ip = "127.0.0.1"
 listen_port = 3333
 # Server's user-facing URL - Default: (none)
 public_url = 
+# Whitelist of client origins to allow - Default: (none) (unrestricted)
+allowed_origins = 
 
 
 [crypto]

--- a/src/config.rs
+++ b/src/config.rs
@@ -103,6 +103,7 @@ pub struct Config {
     pub listen_ip: String,
     pub listen_port: u16,
     pub public_url: String,
+    pub allowed_origins: Option<Vec<String>>,
     pub token_ttl: u16,
     pub keys: Vec<crypto::NamedKey>,
     pub store: store::Store,
@@ -121,6 +122,7 @@ pub struct ConfigBuilder {
     pub listen_ip: String,
     pub listen_port: u16,
     pub public_url: Option<String>,
+    pub allowed_origins: Option<Vec<String>>,
     pub token_ttl: u16,
     pub keyfiles: Vec<String>,
     pub keytext: Option<String>,
@@ -187,6 +189,7 @@ impl ConfigBuilder {
             listen_ip: "127.0.0.1".to_string(),
             listen_port: 3333,
             public_url: None,
+            allowed_origins: None,
             token_ttl: 600,
             keyfiles: Vec::new(),
             keytext: None,
@@ -215,6 +218,7 @@ impl ConfigBuilder {
             if let Some(val) = table.listen_ip { self.listen_ip = val; }
             if let Some(val) = table.listen_port { self.listen_port = val; }
             self.public_url = table.public_url.or(self.public_url.clone());
+            if let Some(val) = table.allowed_origins { self.allowed_origins = Some(val) };
         }
 
         if let Some(table) = toml_config.crypto {
@@ -285,6 +289,7 @@ impl ConfigBuilder {
         if let Some(val) = env_config.broker_ip { self.listen_ip = val }
         if let Some(val) = env_config.broker_port { self.listen_port = val; }
         if let Some(val) = env_config.broker_public_url { self.public_url = Some(val); }
+        if let Some(val) = env_config.broker_allowed_origins { self.allowed_origins = Some(val); }
 
         if let Some(val) = env_config.broker_token_ttl { self.token_ttl = val; }
         if let Some(val) = env_config.broker_keyfiles { self.keyfiles = val; }
@@ -352,6 +357,7 @@ impl ConfigBuilder {
             listen_ip: self.listen_ip,
             listen_port: self.listen_port,
             public_url: self.public_url.unwrap(),
+            allowed_origins: self.allowed_origins,
             token_ttl: self.token_ttl,
             keys: keys,
             store: store,
@@ -376,6 +382,7 @@ impl EnvConfig {
             broker_ip: env::var("BROKER_IP").ok(),
             broker_port: env::var("BROKER_PORT").ok().and_then(|x| x.parse().ok()),
             broker_public_url: env::var("BROKER_PUBLIC_URL").ok(),
+            broker_allowed_origins: env::var("BROKER_ALLOWED_ORIGINS").ok().map(|x| x.split(',').map(|x| x.to_string()).collect()),
 
             broker_token_ttl: env::var("BROKER_TOKEN_TTL").ok().and_then(|x| x.parse().ok()),
             broker_keyfiles: env::var("BROKER_KEYFILES").ok().map(|x| x.split(',').map(|x| x.to_string()).collect()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -304,6 +304,11 @@ broker_handler!(AuthHandler, |app, req| {
     try!(valid_uri(client_id));
     try!(same_origin(client_id, redirect_uri));
     try!(only_origin(client_id));
+    if let Some(ref whitelist) = app.allowed_origins {
+        if !whitelist.contains(&client_id.to_string()) {
+            return Err(BrokerError::Input("the origin is not whitelisted".to_string()));
+        }
+    }
 
     // Per the OAuth2 spec, we may redirect to the RP once we have validated client_id and
     // redirect_uri. In our case, this means we make redirect_uri available to error handling.

--- a/src/serde_types.in.rs
+++ b/src/serde_types.in.rs
@@ -18,6 +18,7 @@ struct TomlServerTable {
     listen_ip: Option<String>,
     listen_port: Option<u16>,
     public_url: Option<String>,
+    allowed_origins: Option<Vec<String>>,
 }
 
 #[derive(Clone,Debug,Deserialize)]
@@ -62,6 +63,7 @@ struct EnvConfig {
     broker_ip: Option<String>,
     broker_port: Option<u16>,
     broker_public_url: Option<String>,
+    broker_allowed_origins: Option<Vec<String>>,
     broker_token_ttl: Option<u16>,
     broker_keyfiles: Option<Vec<String>>,
     broker_keytext: Option<String>,


### PR DESCRIPTION
As per discussion in #45.

I went with a bit more extended configuration, because it felt more natural. This matches the config we have for providers. The alternative, I think, would've been a flat list `redirect_uris`, but it'd be a toplevel field in the config.