### PR TITLE
Remove default config file from Docker image.

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -45,7 +45,6 @@ ENV SSL_CERT_FILE=/certs/ca-certificates.crt \
     SSL_CERT_DIR=/certs \
     BROKER_IP=::
 ENTRYPOINT ["/portier-broker"]
-CMD ["/cfg/config.toml"]
 EXPOSE 3333
 EOF
 docker build -t portier/broker .


### PR DESCRIPTION
It should be possible to configure the container entirely through env
vars now. This also allows changing the location of config.