### PR TITLE
Revert "Require consent for oidc flow."

### DIFF
--- a/src/oidc.rs
+++ b/src/oidc.rs
@@ -93,7 +93,6 @@ pub fn request(app: &Config, email_addr: EmailAddress, client_id: &str, nonce: &
         &utf8_percent_encode(&session, QUERY_ENCODE_SET).to_string(),
         "&login_hint=",
         &utf8_percent_encode(&email_addr.to_string(), QUERY_ENCODE_SET).to_string(),
-        "&prompt=consent",
     ].join("")).map_err(|_| {
         BrokerError::Provider(format!("failed to build valid authorization URL from {}'s 'authorization_endpoint'", domain))
     })


### PR DESCRIPTION
This reverts commit 3d6d378be4a25c64e701e061809bee60d2af86fc.

The Google consent screen uses scary language:

![screenshot from 2016-10-29 16-24-23](https://cloud.githubusercontent.com/assets/24193/19832856/8e657d8c-9df4-11e6-9e20-978735097ca3.png)

![screenshot from 2016-10-29 16-24-36](https://cloud.githubusercontent.com/assets/24193/19832857/9231bae8-9df4-11e6-8ff8-30d6d681255e.png)

