### PR TITLE
Implement implicit flow for Google.

### DIFF
--- a/res/static/fragment_callback.js
+++ b/res/static/fragment_callback.js
@@ -1,0 +1,14 @@
+document.addEventListener('DOMContentLoaded', function() {
+  var form = document.getElementById('form');
+  var params = location.hash.slice(1);
+  var re = /([^&=]+)=([^&]*)/g;
+  var match;
+  while (match = re.exec(params)) {
+    var el = document.createElement('input');
+    el.type = 'hidden';
+    el.name = decodeURIComponent(match[1]);
+    el.value = decodeURIComponent(match[2]);
+    form.appendChild(el);
+  }
+  form.submit();
+});

--- a/src/config.rs
+++ b/src/config.rs
@@ -93,6 +93,8 @@ pub struct Templates {
     pub error: Template,
     /// A dummy form used to redirect back to the RP with a POST request.
     pub forward: Template,
+    /// A dummy form used to capture fragment parameters.
+    pub fragment_callback: Template,
 }
 
 
@@ -111,6 +113,7 @@ impl Default for Templates {
             email_text: Self::compile_template("tmpl/email_text.mustache"),
             error: Self::compile_template("tmpl/error.mustache"),
             forward: Self::compile_template("tmpl/forward.mustache"),
+            fragment_callback: Self::compile_template("tmpl/fragment_callback.mustache"),
         }
     }
 }

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -143,6 +143,13 @@ pub fn session_id(email: &EmailAddress, client_id: &str) -> String {
 }
 
 
+pub fn nonce() -> String {
+    let mut rng = OsRng::new().expect("unable to create rng");
+    let rand_bytes: Vec<u8> = (0..16).map(|_| rng.gen()).collect();
+    rand_bytes.to_base64(base64::URL_SAFE)
+}
+
+
 /// Helper function to deserialize key from JWK Key Set.
 ///
 /// Searches the provided JWK Key Set Value for the key matching the given

--- a/src/email_bridge.rs
+++ b/src/email_bridge.rs
@@ -6,8 +6,7 @@ use super::error::{BrokerError, BrokerResult};
 use super::lettre::email::EmailBuilder;
 use super::lettre::transport::EmailTransport;
 use super::lettre::transport::smtp::SmtpTransportBuilder;
-use super::{Config, create_jwt};
-use super::crypto::session_id;
+use super::{Config, create_jwt, crypto};
 use std::collections::HashMap;
 use std::error::Error;
 use std::iter::Iterator;
@@ -30,7 +29,7 @@ const CODE_CHARS: &'static [u8] = b"13456789abcdefghijkmnopqrstuwxyz";
 pub fn request(app: &Config, email_addr: EmailAddress, client_id: &str, nonce: &str, redirect_uri: &Url)
                -> BrokerResult<String> {
 
-    let session = session_id(&email_addr, client_id);
+    let session = crypto::session_id(&email_addr, client_id);
 
     // Generate a 12-character one-time pad.
     let chars = String::from_utf8((0..12).map(|_| {

--- a/src/handlers/oauth2.rs
+++ b/src/handlers/oauth2.rs
@@ -1,26 +1,49 @@
 use config::Config;
 use error::{BrokerResult, BrokerError};
 use iron::{IronResult, Plugin, Request, Response, Url};
+use iron::headers::ContentType;
+use iron::method::Method;
 use iron::middleware::Handler;
+use iron::modifiers;
+use iron::status;
 use oidc_bridge;
 use std::sync::Arc;
 use super::{RedirectUri, handle_error, return_to_relier};
-use urlencoded::UrlEncodedQuery;
+use urlencoded::UrlEncodedBody;
 
 
 /// Iron handler for OAuth callbacks
 ///
 /// After the user allows or denies the Authentication Request with the famous
 /// identity provider, they will be redirected back to the callback handler.
-/// Verify the callback data and return the resulting token or error.
+///
+/// For providers that don't support `response_type=form_post`, we capture the
+/// fragment parameters in JavaScript and emulate the POST request.
+///
+/// Once we have a POST request, we can verify the callback data and return the
+/// resulting token to the relying party, or error.
 broker_handler!(Callback, |app, req| {
-    let params = req.compute::<UrlEncodedQuery>()
-                    .map_err(|_| BrokerError::Input("no query string in GET request".to_string()))?;
+    match req.method {
+        Method::Get => {
+            Ok(Response::with((status::Ok,
+                               modifiers::Header(ContentType::html()),
+                               app.templates.fragment_callback.render(&[]))))
+        },
+        Method::Post => {
+            let params = try!(req.compute::<UrlEncodedBody>()
+                .map_err(|_| BrokerError::Input("no query string in POST data".to_string())));
 
-    let stored = app.store.get_session("oidc", &try_get_param!(params, "state"))?;
-    req.extensions.insert::<RedirectUri>(Url::parse(&stored["redirect"]).expect("unable to parse stored redirect uri"));
+            let stored = try!(app.store.get_session("oidc", &try_get_param!(params, "state")));
+            req.extensions.insert::<RedirectUri>(
+                Url::parse(&stored["redirect"]).expect("redirect_uri missing from session")
+            );
 
-    let code = try_get_param!(params, "code");
-    let (jwt, redirect_uri) = oidc_bridge::verify(app, &stored, code)?;
-    Ok(Response::with(return_to_relier(app, &redirect_uri, &[("id_token", &jwt)])))
+            let id_token = try_get_param!(params, "id_token");
+            let (jwt, redirect_uri) = try!(oidc_bridge::verify(app, &stored, id_token));
+            Ok(Response::with(return_to_relier(app, &redirect_uri, &[("id_token", &jwt)])))
+        },
+        _ => {
+            panic!("Unsupported method: {}", req.method)
+        }
+    }
 });

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,7 +82,8 @@ fn main() {
         post_auth: post "/auth" => broker::handlers::oidc::Auth::new(&app),
 
         // OpenID Connect relying party endpoints
-        callback:  get  "/callback" => broker::handlers::oauth2::Callback::new(&app),
+        get_cb:    get  "/callback" => broker::handlers::oauth2::Callback::new(&app),
+        post_cb:   post "/callback" => broker::handlers::oauth2::Callback::new(&app),
 
         // Lastly, fall back to trying to serve static files out of ./res/
         static:    get  "/*" => staticfile::Static::new(Path::new("./res/")),

--- a/tmpl/forward.mustache
+++ b/tmpl/forward.mustache
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>Portier &ndash; Forwarding...</title>
-    <script src="/static/forward.js"></script>
+    <script src="/static/forward.js" defer></script>
   </head>
   <body>
     <form id="form" action="{{ redirect_uri }}" method="post">

--- a/tmpl/fragment_callback.mustache
+++ b/tmpl/fragment_callback.mustache
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Portier &ndash; Forwarding...</title>
+    <script src="/static/fragment_callback.js" defer></script>
+  </head>
+  <body>
+    <form id="form" action="/callback" method="post"></form>
+  </body>
+</html>


### PR DESCRIPTION
Alternative to #84. See also the discussion in #85.

When using the implicit flow with Google, there is apparently never a prompt, not even on the first login. Perhaps that's because we already provide a `login_hint` as well.

We're also never listed in 'connected apps' in Google settings, because we don't have an access token. That's pretty good too. (However, if we want to send `prompt=consent` in the future, we _do_ get listed, and we _do_ get scary warnings the second login and beyond, like in #80. Maybe there are more options to control that.)

Google doesn't support `response_mode=form_post`, so we add a small page inbetween to capture the fragment parameters and POST them to us.

This removes a roundtrip on the server side, but adds a roundtrip on the client side. However, this also eliminates lingering access tokens, and maybe even preps us for supporting more OIDC providers in the future.
