### PR TITLE
Seperate form login from primary message

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -10,7 +10,7 @@ body {
   color: #444;
   font: normal 1em sans-serif;
 }
-p, .entry {
+h1, p, hr, .entry {
   margin: 24px;
 }
 .head {
@@ -53,8 +53,6 @@ hr {
   height: 0;
   border-top: 1px solid rgba(0, 0, 0, 0.1);
   border-bottom: 1px solid rgba(255, 255, 255, 0.3);
-  margin-left: 24px;
-  margin-right: 24px;
 }
 
 aside p, aside .entry button, aside .entry input {

--- a/static/style.css
+++ b/static/style.css
@@ -48,3 +48,13 @@ p, .entry {
   background: #36abdf;
   color: #fff;
 }
+hr {
+  border: 0;
+  height: 0;
+  border-top: 1px solid rgba(0, 0, 0, 0.1);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.3);
+}
+
+aside p, aside .entry button, aside .entry input {
+  font-size: 0.9em;
+}

--- a/static/style.css
+++ b/static/style.css
@@ -53,6 +53,8 @@ hr {
   height: 0;
   border-top: 1px solid rgba(0, 0, 0, 0.1);
   border-bottom: 1px solid rgba(255, 255, 255, 0.3);
+  margin-left: 24px;
+  margin-right: 24px;
 }
 
 aside p, aside .entry button, aside .entry input {

--- a/tmpl/confirm_email.mustache
+++ b/tmpl/confirm_email.mustache
@@ -17,7 +17,7 @@
           <em>{{ client_id }}</em>
         </p>
       </main>
-      < hr />
+      <hr />
       <aside>
         <p>
           Alternatively, enter the code from the email

--- a/tmpl/confirm_email.mustache
+++ b/tmpl/confirm_email.mustache
@@ -8,24 +8,29 @@
   </head>
   <body>
     <div class="container">
-      <p class="head">
-        We've sent you an email to confirm your address.
-      </p>
-      <p>
-        Use the link in that email to login to:<br>
-        <em>{{ client_id }}</em>
-      </p>
-      <p>
-        Alternatively, enter the code from the email
-        to continue in this browser tab:
-      </p>
-      <form id="form" action="/confirm" method="get">
-        <input type="hidden" name="session" value="{{ session_id }}">
-        <div class="entry">
-          <input type="text" name="code" maxlength="6" autofocus>
-          <button type="submit">Login</button>
-        </div>
-      </form>
+      <main>
+        <h1 class="head">
+          We've sent you an email to confirm your address.
+        </h1>
+        <p>
+          Use the link in that email to login to:<br>
+          <em>{{ client_id }}</em>
+        </p>
+      </main>
+      < hr />
+      <aside>
+        <p>
+          Alternatively, enter the code from the email
+          to continue in this browser tab:
+        </p>
+        <form id="form" action="/confirm" method="get">
+          <input type="hidden" name="session" value="{{ session_id }}">
+          <div class="entry">
+            <input type="text" name="code" maxlength="6" autofocus>
+            <button type="submit">Login</button>
+          </div>
+        </form>
+      </aside>
    </div>
 </body>
 </html>


### PR DESCRIPTION
The important message is not the form, but that an email was sent. This minor styling change tries to support that by making the form elements smaller and adding a styled hr, also html semantics.