### PR TITLE
Middleware refactor and canonical origin enforcement

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,8 +14,8 @@ extern crate url;
 extern crate urlencoded;
 
 use emailaddress::EmailAddress;
-use iron::headers::{ContentType, Location, StrictTransportSecurity};
-use iron::middleware::{Handler, BeforeMiddleware, AfterMiddleware};
+use iron::headers::{ContentType, Location};
+use iron::middleware::Handler;
 use iron::modifiers;
 use iron::method::Method;
 use iron::prelude::*;
@@ -34,6 +34,7 @@ pub mod config;
 pub use config::{Config, ConfigBuilder};
 pub mod crypto;
 pub mod email;
+pub mod middleware;
 pub mod oidc;
 pub mod store;
 pub mod store_cache;
@@ -42,11 +43,6 @@ use validation::{valid_uri, only_origin, same_origin};
 
 use error::{BrokerResult, BrokerError};
 
-header! { (ContentSecurityPolicy, "Content-Security-Policy") => [String] }
-header! { (XContentSecurityPolicy, "X-Content-Security-Policy") => [String] }
-header! { (XContentTypeOptions, "X-Content-Type-Options") => [String] }
-header! { (XXSSProtection, "X-XSS-Protection") => [String] }
-header! { (XFrameOptions, "X-Frame-Options") => [String] }
 
 
 /// Iron extension key we use to store the `redirect_uri`.
@@ -193,49 +189,6 @@ fn handle_error(app: &Config, req: &mut Request, err: BrokerError) -> IronResult
                                          ("error", "internal server error"),
                                      ]))))
         },
-    }
-}
-
-
-/// Middleware that logs each request.
-pub struct LogMiddleware;
-impl BeforeMiddleware for LogMiddleware {
-    fn before(&self, req: &mut Request) -> IronResult<()> {
-        info!("{} {}", req.method, req.url);
-        Ok(())
-    }
-}
-
-
-/// Middleware that sets common headers.
-pub struct DefaultHeadersMiddleware;
-impl DefaultHeadersMiddleware {
-    fn set_headers(&self, res: &mut Response) {
-        // Specify a tight content security policy. We need to be able to POST
-        // redirect anywhere, and run our own inline scripts.
-        let csp = vec![
-            "sandbox allow-scripts allow-forms",
-            "default-src 'none'",
-            "script-src 'self'",
-            "style-src 'self'",
-            "form-action *",
-        ].join("; ");
-        res.set_mut((modifiers::Header(StrictTransportSecurity::excluding_subdomains(31536000u64)),
-                     modifiers::Header(ContentSecurityPolicy(csp.clone())),
-                     modifiers::Header(XContentSecurityPolicy(csp)),
-                     modifiers::Header(XContentTypeOptions("nosniff".to_string())),
-                     modifiers::Header(XXSSProtection("1; mode=block".to_string())),
-                     modifiers::Header(XFrameOptions("DENY".to_string()))));
-    }
-}
-impl AfterMiddleware for DefaultHeadersMiddleware {
-    fn after(&self, _: &mut Request, mut res: Response) -> IronResult<Response> {
-        self.set_headers(&mut res);
-        Ok(res)
-    }
-    fn catch(&self, _: &mut Request, mut err: IronError) -> IronResult<Response> {
-        self.set_headers(&mut err.response);
-        Err(err)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,8 +81,8 @@ fn main() {
     };
 
     let mut chain = Chain::new(router);
-    chain.link_before(broker::LogMiddleware);
-    chain.link_after(broker::DefaultHeadersMiddleware);
+    chain.link_before(broker::middleware::LogMiddleware);
+    chain.link_after(broker::middleware::DefaultHeadersMiddleware);
 
     let ipaddr = std::net::IpAddr::from_str(&app.listen_ip).unwrap();
     let socket = std::net::SocketAddr::new(ipaddr, app.listen_port);

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,6 +82,7 @@ fn main() {
 
     let mut chain = Chain::new(router);
     chain.link_before(broker::middleware::LogRequest);
+    chain.link_before(broker::middleware::EnforceOrigin::new(&app.public_url));
     chain.link_after(broker::middleware::SecurityHeaders);
 
     let ipaddr = std::net::IpAddr::from_str(&app.listen_ip).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,8 +81,8 @@ fn main() {
     };
 
     let mut chain = Chain::new(router);
-    chain.link_before(broker::middleware::LogMiddleware);
-    chain.link_after(broker::middleware::DefaultHeadersMiddleware);
+    chain.link_before(broker::middleware::LogRequest);
+    chain.link_after(broker::middleware::SecurityHeaders);
 
     let ipaddr = std::net::IpAddr::from_str(&app.listen_ip).unwrap();
     let socket = std::net::SocketAddr::new(ipaddr, app.listen_port);

--- a/src/middleware/headers.rs
+++ b/src/middleware/headers.rs
@@ -10,8 +10,8 @@ header! { (XXSSProtection, "X-XSS-Protection") => [String] }
 header! { (XFrameOptions, "X-Frame-Options") => [String] }
 
 /// Middleware that sets common headers.
-pub struct DefaultHeadersMiddleware;
-impl DefaultHeadersMiddleware {
+pub struct SecurityHeaders;
+impl SecurityHeaders {
     fn set_headers(&self, res: &mut Response) {
         // Specify a tight content security policy. We need to be able to POST
         // redirect anywhere, and run our own inline scripts.
@@ -30,7 +30,7 @@ impl DefaultHeadersMiddleware {
                      modifiers::Header(XFrameOptions("DENY".to_string()))));
     }
 }
-impl AfterMiddleware for DefaultHeadersMiddleware {
+impl AfterMiddleware for SecurityHeaders {
     fn after(&self, _: &mut Request, mut res: Response) -> IronResult<Response> {
         self.set_headers(&mut res);
         Ok(res)

--- a/src/middleware/headers.rs
+++ b/src/middleware/headers.rs
@@ -9,34 +9,56 @@ header! { (XContentTypeOptions, "X-Content-Type-Options") => [String] }
 header! { (XXSSProtection, "X-XSS-Protection") => [String] }
 header! { (XFrameOptions, "X-Frame-Options") => [String] }
 
-/// Middleware that sets common headers.
+/// Middleware that enforces common security headers on all outgoing responses.
 pub struct SecurityHeaders;
-impl SecurityHeaders {
-    fn set_headers(&self, res: &mut Response) {
-        // Specify a tight content security policy. We need to be able to POST
-        // redirect anywhere, and run our own inline scripts.
-        let csp = vec![
-            "sandbox allow-scripts allow-forms",
-            "default-src 'none'",
-            "script-src 'self'",
-            "style-src 'self'",
-            "form-action *",
-        ].join("; ");
-        res.set_mut((modifiers::Header(StrictTransportSecurity::excluding_subdomains(31536000u64)),
-                     modifiers::Header(ContentSecurityPolicy(csp.clone())),
-                     modifiers::Header(XContentSecurityPolicy(csp)),
-                     modifiers::Header(XContentTypeOptions("nosniff".to_string())),
-                     modifiers::Header(XXSSProtection("1; mode=block".to_string())),
-                     modifiers::Header(XFrameOptions("DENY".to_string()))));
-    }
-}
+
 impl AfterMiddleware for SecurityHeaders {
     fn after(&self, _: &mut Request, mut res: Response) -> IronResult<Response> {
-        self.set_headers(&mut res);
+        set_headers(&mut res);
         Ok(res)
     }
+
     fn catch(&self, _: &mut Request, mut err: IronError) -> IronResult<Response> {
-        self.set_headers(&mut err.response);
+        set_headers(&mut err.response);
         Err(err)
+    }
+}
+
+/// Mutate an `iron::Response` to set common security headers.
+fn set_headers(res: &mut Response) {
+    // Specify a tight content security policy. We need to be able to POST
+    // redirect anywhere, and run our own inline scripts.
+    let csp = vec![
+        "sandbox allow-scripts allow-forms",
+        "default-src 'none'",
+        "script-src 'self'",
+        "style-src 'self'",
+        "form-action *",
+    ].join("; ");
+
+    res.set_mut((modifiers::Header(StrictTransportSecurity::excluding_subdomains(31536000u64)),
+                 modifiers::Header(ContentSecurityPolicy(csp.clone())),
+                 modifiers::Header(XContentSecurityPolicy(csp)),
+                 modifiers::Header(XContentTypeOptions("nosniff".to_string())),
+                 modifiers::Header(XXSSProtection("1; mode=block".to_string())),
+                 modifiers::Header(XFrameOptions("DENY".to_string()))));
+}
+
+#[cfg(test)]
+mod tests {
+    use iron::Response;
+    use super::set_headers;
+
+    #[test]
+    fn sets_expected_headers() {
+        let mut res = Response::new();
+        set_headers(&mut res);
+
+        assert!(res.headers.get_raw("Strict-Transport-Security").is_some());
+        assert!(res.headers.get_raw("Content-Security-Policy").is_some());
+        assert!(res.headers.get_raw("X-Content-Security-Policy").is_some());
+        assert!(res.headers.get_raw("X-Content-Type-Options").is_some());
+        assert!(res.headers.get_raw("X-XSS-Protection").is_some());
+        assert!(res.headers.get_raw("X-Frame-Options").is_some());
     }
 }

--- a/src/middleware/headers.rs
+++ b/src/middleware/headers.rs
@@ -1,0 +1,42 @@
+use hyper::header::StrictTransportSecurity;
+use iron::middleware::AfterMiddleware;
+use iron::modifiers;
+use iron::{IronError, IronResult, Request, Response, Set};
+
+header! { (ContentSecurityPolicy, "Content-Security-Policy") => [String] }
+header! { (XContentSecurityPolicy, "X-Content-Security-Policy") => [String] }
+header! { (XContentTypeOptions, "X-Content-Type-Options") => [String] }
+header! { (XXSSProtection, "X-XSS-Protection") => [String] }
+header! { (XFrameOptions, "X-Frame-Options") => [String] }
+
+/// Middleware that sets common headers.
+pub struct DefaultHeadersMiddleware;
+impl DefaultHeadersMiddleware {
+    fn set_headers(&self, res: &mut Response) {
+        // Specify a tight content security policy. We need to be able to POST
+        // redirect anywhere, and run our own inline scripts.
+        let csp = vec![
+            "sandbox allow-scripts allow-forms",
+            "default-src 'none'",
+            "script-src 'self'",
+            "style-src 'self'",
+            "form-action *",
+        ].join("; ");
+        res.set_mut((modifiers::Header(StrictTransportSecurity::excluding_subdomains(31536000u64)),
+                     modifiers::Header(ContentSecurityPolicy(csp.clone())),
+                     modifiers::Header(XContentSecurityPolicy(csp)),
+                     modifiers::Header(XContentTypeOptions("nosniff".to_string())),
+                     modifiers::Header(XXSSProtection("1; mode=block".to_string())),
+                     modifiers::Header(XFrameOptions("DENY".to_string()))));
+    }
+}
+impl AfterMiddleware for DefaultHeadersMiddleware {
+    fn after(&self, _: &mut Request, mut res: Response) -> IronResult<Response> {
+        self.set_headers(&mut res);
+        Ok(res)
+    }
+    fn catch(&self, _: &mut Request, mut err: IronError) -> IronResult<Response> {
+        self.set_headers(&mut err.response);
+        Err(err)
+    }
+}

--- a/src/middleware/logging.rs
+++ b/src/middleware/logging.rs
@@ -1,0 +1,11 @@
+use iron::middleware::BeforeMiddleware;
+use iron::{IronResult, Request};
+
+/// Middleware that logs each request.
+pub struct LogMiddleware;
+impl BeforeMiddleware for LogMiddleware {
+    fn before(&self, req: &mut Request) -> IronResult<()> {
+        info!("{} {}", req.method, req.url);
+        Ok(())
+    }
+}

--- a/src/middleware/logging.rs
+++ b/src/middleware/logging.rs
@@ -2,8 +2,8 @@ use iron::middleware::BeforeMiddleware;
 use iron::{IronResult, Request};
 
 /// Middleware that logs each request.
-pub struct LogMiddleware;
-impl BeforeMiddleware for LogMiddleware {
+pub struct LogRequest;
+impl BeforeMiddleware for LogRequest {
     fn before(&self, req: &mut Request) -> IronResult<()> {
         info!("{} {}", req.method, req.url);
         Ok(())

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -1,5 +1,5 @@
 mod logging;
-pub use self::logging::LogMiddleware;
+pub use self::logging::LogRequest;
 
 mod headers;
-pub use self::headers::DefaultHeadersMiddleware;
+pub use self::headers::SecurityHeaders;

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -3,3 +3,6 @@ pub use self::logging::LogRequest;
 
 mod headers;
 pub use self::headers::SecurityHeaders;
+
+mod origin;
+pub use self::origin::EnforceOrigin;

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -1,0 +1,5 @@
+mod logging;
+pub use self::logging::LogMiddleware;
+
+mod headers;
+pub use self::headers::DefaultHeadersMiddleware;

--- a/src/middleware/origin.rs
+++ b/src/middleware/origin.rs
@@ -1,0 +1,83 @@
+use hyper::status::StatusCode;
+use iron::middleware::BeforeMiddleware;
+use iron::modifiers;
+use iron::{IronError, IronResult, Request};
+use std::error::Error;
+use std::fmt;
+use url::Origin::{Opaque, Tuple};
+use url;
+
+/// Middleware that redirects requests to the broker's canonical public_url.
+pub struct EnforceOrigin {
+    origin: url::Origin,
+}
+
+impl EnforceOrigin {
+    pub fn new(uri: &str) -> EnforceOrigin {
+        let origin =
+            url::Url::parse(uri).expect(format!("unable to parse uri: {}", uri).as_str()).origin();
+
+        EnforceOrigin { origin: origin }
+    }
+}
+
+// TODO: Extract the uri mutation into a standalone function?
+// TODO: Supress error messages associated with failure here.
+impl BeforeMiddleware for EnforceOrigin {
+    fn before(&self, req: &mut Request) -> IronResult<()> {
+        let mut uri = req.url.clone().into_generic_url();
+
+        // If the request and canonical origins match, everything is fine.
+        if self.origin == uri.origin() {
+            return Ok(());
+        }
+
+        // Otherwise, extract the configured, canonical origin...
+        let (scheme, host, port) = match self.origin {
+            Tuple(ref scheme, ref host, ref port) => (scheme, host, port),
+            Opaque(_) => {
+                return Err(IronError::new(OriginError::Opaque, StatusCode::InternalServerError))
+            }
+        };
+
+        // ...mutate the request URI to point to the canonical origin...
+        if uri.set_scheme(scheme).is_err() ||
+           uri.set_host(Some(&format!("{}", host))).is_err() ||
+           uri.set_port(Some(*port)).is_err() {
+            return Err(IronError::new(OriginError::Mutation, StatusCode::InternalServerError));
+        }
+
+        // ...and redirect to it.
+        let status = StatusCode::TemporaryRedirect;
+        let location = modifiers::RedirectRaw(uri.to_string());
+
+        Err(IronError::new(OriginError::Mismatch, (status, location)))
+    }
+}
+
+#[derive(Debug)]
+enum OriginError {
+    Mismatch,
+    Mutation,
+    Opaque,
+}
+
+impl fmt::Display for OriginError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            OriginError::Mismatch => write!(f, "origins did not match eachother"),
+            OriginError::Mutation => write!(f, "unable to set new scheme, host, or port"),
+            OriginError::Opaque => write!(f, "origin was opaque"),
+        }
+    }
+}
+
+impl Error for OriginError {
+    fn description(&self) -> &str {
+        match *self {
+            OriginError::Mismatch => "origins did not match eachother",
+            OriginError::Mutation => "unable to set new scheme, host, or port",
+            OriginError::Opaque => "origin was opaque",
+        }
+    }
+}


### PR DESCRIPTION
This pull request:

- Extracts middleware out of `lib.rs` and into its own module hierarchy.
- Refactors and adds basic unit tests for our security headers middleware.
- Introduces a new middleware to redirect incoming requests to the broker's canonical origin, as derived from `public_url`, which fixes #83.