### PR TITLE
Feature insensitive codes

### DIFF
--- a/src/email.rs
+++ b/src/email.rs
@@ -21,9 +21,7 @@ use url::percent_encoding::{utf8_percent_encode, QUERY_ENCODE_SET};
 /// and 'O'.)
 const CODE_CHARS: &'static [char] = &[
     '2', '3', '4', '6', '7', '9', 'a', 'c', 'd', 'e', 'f', 'g', 'h', 'j', 'k',
-    'm', 'n', 'p', 'q', 'r', 't', 'v', 'w', 'x', 'y', 'z', 'A', 'C', 'E', 'F',
-    'G', 'H', 'J', 'K', 'L', 'M', 'N', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W',
-    'X', 'Y', 'Z',
+    'm', 'n', 'p', 'q', 'r', 't', 'v', 'w', 'x', 'y', 'z'
 ];
 
 
@@ -41,8 +39,8 @@ pub fn request(app: &Config, email_addr: EmailAddress, client_id: &str, nonce: &
 
     let session = session_id(&email_addr, client_id);
 
-    // Generate a 6-character one-time pad.
-    let chars: String = (0..6).map(|_| CODE_CHARS[rand::random::<usize>() % CODE_CHARS.len()]).collect();
+    // Generate a 8-character one-time pad.
+    let chars: String = (0..8).map(|_| CODE_CHARS[rand::random::<usize>() % CODE_CHARS.len()]).collect();
 
     // Store data for this request in Redis, to reference when user uses
     // the generated link.
@@ -93,7 +91,7 @@ pub fn request(app: &Config, email_addr: EmailAddress, client_id: &str, nonce: &
 pub fn verify(app: &Config, stored: &HashMap<String, String>, code: &str)
               -> BrokerResult<(String, String)> {
 
-    if code != &stored["code"] {
+    if code.to_lowercase() != (&stored["code"]).to_string() {
         return Err(BrokerError::Input("incorrect code".to_string()));
     }
 

--- a/src/email.rs
+++ b/src/email.rs
@@ -90,7 +90,7 @@ pub fn request(app: &Config, email_addr: EmailAddress, client_id: &str, nonce: &
 pub fn verify(app: &Config, stored: &HashMap<String, String>, code: &str)
               -> BrokerResult<(String, String)> {
 
-    if code.to_lowercase() != (&stored["code"]).to_string() {
+    if &code.to_lowercase() != &stored["code"] {
         return Err(BrokerError::Input("incorrect code".to_string()));
     }
 

--- a/src/email.rs
+++ b/src/email.rs
@@ -90,7 +90,7 @@ pub fn request(app: &Config, email_addr: EmailAddress, client_id: &str, nonce: &
 pub fn verify(app: &Config, stored: &HashMap<String, String>, code: &str)
               -> BrokerResult<(String, String)> {
 
-    if &code.to_lowercase() != &stored["code"] {
+    if &code.trim().to_lowercase() != &stored["code"] {
         return Err(BrokerError::Input("incorrect code".to_string()));
     }
 

--- a/src/email.rs
+++ b/src/email.rs
@@ -17,11 +17,10 @@ use url::percent_encoding::{utf8_percent_encode, QUERY_ENCODE_SET};
 ///
 /// Currently includes all numbers, lower- and upper-case ASCII letters,
 /// except those that could potentially cause confusion when reading back.
-/// (That is, '1', '5', '8', '0', 'b', 'i', 'l', 'o', 's', 'u', 'B', 'D', 'I'
-/// and 'O'.)
+/// (That is, '1', '5', '0', 'b', 'l')
 const CODE_CHARS: &'static [char] = &[
-    '2', '3', '4', '6', '7', '9', 'a', 'c', 'd', 'e', 'f', 'g', 'h', 'j', 'k',
-    'm', 'n', 'p', 'q', 'r', 't', 'v', 'w', 'x', 'y', 'z'
+    '2', '3', '4', '6', '7', '8', '9', 'a', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k',
+    'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z'
 ];
 
 

--- a/tmpl/confirm_email.mustache
+++ b/tmpl/confirm_email.mustache
@@ -26,7 +26,7 @@
         <form id="form" action="/confirm" method="get">
           <input type="hidden" name="session" value="{{ session_id }}">
           <div class="entry">
-            <input type="text" name="code" maxlength="6" autofocus>
+            <input type="text" name="code" maxlength="8" autofocus>
             <button type="submit">Login</button>
           </div>
         </form>

--- a/tmpl/confirm_email.mustache
+++ b/tmpl/confirm_email.mustache
@@ -26,7 +26,7 @@
         <form id="form" action="/confirm" method="get">
           <input type="hidden" name="session" value="{{ session_id }}">
           <div class="entry">
-            <input type="text" name="code" maxlength="8" autofocus>
+            <input type="text" name="code" maxlength="12" autofocus>
             <button type="submit">Login</button>
           </div>
         </form>


### PR DESCRIPTION
This should fix #35 by using only lowercase chars for generating the otp, and transforming the entered code to lowercase as well.

We have to think about the potential issues for #69 – I addressed this partly in the second commit by allowing more letters I think are not really confusing. Also, whether the code should be presented uppercase or lowercase in the mail was not clear to me. Steam for example uses uppercase. But it's easy enough to change that later, also without modifying how the code is generated. 