### PR TITLE
Add auth per email rate limit.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -104,6 +104,15 @@ discovery_url   BROKER_GMAIL_DISCOVERY "https://accounts.google.com/.well-known/
 issuer_domain   BROKER_GMAIL_ISSUER    "accounts.google.com"
 =============== ====================== ==============================================================
 
+**[limits] section:**
+
+=============== ======================== ================
+``config.toml`` Environment Variable     Default
+=============== ======================== ================
+auth            BROKER_LIMITS_AUTH       [] (empty array)
+auth_email      BROKER_LIMITS_AUTH_EMAIL [] (empty array)
+=============== ======================== ================
+
 The example configuration file, ``config.toml.dist``, includes reasonable default
 values for most settings, but you must explicitly set:
 
@@ -124,6 +133,13 @@ specify:
 * ``providers."gmail.com".secret``: Your Google OAuth API Secret Key
 
 You can create encryption keys with ``openssl genrsa 4096 > private.pem``
+
+Rate limits in the `limits` section are specified as an array of strings, where
+each strings is in the format: `"<name>:<max_count>:<timespan>:<granularity>"`.
+The `name` is a Redis subkey name for the counter. The end result is to allow
+`max_count` requests per `timespan` (in seconds) with a sliding window. To
+prevent flooding memory, requests are counted in smaller buckets of
+`granularity` (in seconds). The `timespan` must be a multiple of `granularity`.
 
 Contributing
 ------------

--- a/config.toml.dist
+++ b/config.toml.dist
@@ -51,3 +51,10 @@ secret =
 discovery_url = "https://accounts.google.com/.well-known/openid-configuration"
 # Google OpenID Connect id_token issuer domain - Default: "accounts.google.com"
 issuer_domain = "accounts.google.com"
+
+
+[limits]
+# Limit the number of session of any kind.
+auth = ["per-second:3:1:1", "per-minute:20:60:5"]
+# Limit the number of email loop authentications.
+auth_email = ["per-second:1:1:1", "per-minute:10:60:5"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ pub mod handlers;
 pub mod oidc_bridge;
 pub mod store;
 pub mod store_cache;
+pub mod store_limits;
 pub mod validation;
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,7 +63,9 @@ fn main() {
         });
     }
     builder.update_from_common_env();
-    builder.update_from_broker_env();
+    builder.update_from_broker_env().unwrap_or_else(|err| {
+        panic!(format!("failed to parse environment variables: {}", err.description()))
+    });
     let app = Arc::new(builder.done().unwrap_or_else(|err| {
         panic!(format!("failed to build configuration: {}", err.description()))
     }));

--- a/src/serde_types.in.rs
+++ b/src/serde_types.in.rs
@@ -11,6 +11,7 @@ struct TomlConfig {
     redis: Option<TomlRedisTable>,
     smtp: Option<TomlSmtpTable>,
     providers: Option<HashMap<String, TomlProviderTable>>,
+    limits: Option<TomlLimitsTable>,
 }
 
 #[derive(Clone,Debug,Deserialize)]
@@ -53,6 +54,12 @@ struct TomlProviderTable {
     issuer_domain: Option<String>,
 }
 
+#[derive(Clone,Debug,Deserialize)]
+struct TomlLimitsTable {
+    auth: Option<Vec<LimitConfig>>,
+    auth_email: Option<Vec<LimitConfig>>,
+}
+
 
 /// Intermediate structure for deserializing environment variables
 ///
@@ -80,4 +87,6 @@ struct EnvConfig {
     broker_gmail_secret: Option<String>,
     broker_gmail_discovery: Option<String>,
     broker_gmail_issuer: Option<String>,
+    broker_limits_auth: Option<Vec<LimitConfig>>,
+    broker_limits_auth_email: Option<Vec<LimitConfig>>,
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -1,13 +1,11 @@
 use std::collections::HashMap;
 use super::error::{BrokerResult, BrokerError};
 use super::redis::{self, Commands, PipelineCommands};
-use super::store_cache::StoreCache;
 
 
 #[derive(Clone)]
 pub struct Store {
     pub client: redis::Client,
-    pub cache: StoreCache,
     pub expire_sessions: usize, // TTL of session keys, in seconds
     pub expire_cache: usize, // TTL of cache keys, in seconds
     pub max_response_size: u64, // Maximum size of HTTP GET responses
@@ -21,7 +19,6 @@ impl Store {
             Err(_) => Err("error opening store connection"),
             Ok(client) => Ok(Store {
                 client: client,
-                cache: StoreCache,
                 expire_sessions: expire_sessions,
                 expire_cache: expire_cache,
                 max_response_size: max_response_size,

--- a/src/store_cache.rs
+++ b/src/store_cache.rs
@@ -32,57 +32,52 @@ impl<'a> CacheKey<'a> {
 }
 
 
-#[derive(Clone)]
-pub struct StoreCache;
+/// Fetch `url` from cache or using a HTTP GET request, and parse the response as JSON. The
+/// cache is stored in `store` with `key`. The `session` is used to make the HTTP GET request,
+/// if necessary.
+pub fn fetch_json_url(store: &Store, key: CacheKey, session: &HttpClient, url: &str)
+                      -> BrokerResult<Value> {
 
-impl StoreCache {
-    /// Fetch `url` from cache or using a HTTP GET request, and parse the response as JSON. The
-    /// cache is stored in `store` with `key`. The `session` is used to make the HTTP GET request,
-    /// if necessary.
-    pub fn fetch_json_url(&self, store: &Store, key: CacheKey, session: &HttpClient, url: &str)
-                     -> BrokerResult<Value> {
+    // Try to retrieve the result from cache.
+    let key_str = key.to_string();
+    let stored: Option<String> = store.client.get(&key_str)?;
+    stored.map_or_else(|| {
 
-        // Try to retrieve the result from cache.
-        let key_str = key.to_string();
-        let stored: Option<String> = store.client.get(&key_str)?;
-        stored.map_or_else(|| {
+        // Cache miss, make a request.
+        let rsp = session.get(url).send()?;
 
-            // Cache miss, make a request.
-            let rsp = session.get(url).send()?;
-
-            // Grab the max-age directive from the Cache-Control header.
-            let max_age = rsp.headers.get().map_or(0, |header: &HyCacheControl| {
-                for dir in header.iter() {
-                    if let HyCacheDirective::MaxAge(seconds) = *dir {
-                        return seconds;
-                    }
+        // Grab the max-age directive from the Cache-Control header.
+        let max_age = rsp.headers.get().map_or(0, |header: &HyCacheControl| {
+            for dir in header.iter() {
+                if let HyCacheDirective::MaxAge(seconds) = *dir {
+                    return seconds;
                 }
-                0
-            });
-
-            // We read up to size+1, because we use the extra byte as a
-            // sentinel to detect responses that exceed our maximum size.
-            let mut data = String::new();
-            let bytes_read = rsp.take(store.max_response_size + 1).read_to_string(&mut data)?;
-            if bytes_read as u64 > store.max_response_size {
-                return Err(BrokerError::Custom("response exceeded the size limit".to_string()))
             }
+            0
+        });
 
-            // Cache the response for at least `expire_cache`, but honor longer `max-age`.
-            let seconds = max(store.expire_cache, max_age as usize);
-            store.client.set_ex(&key_str, &data, seconds)?;
+        // We read up to size+1, because we use the extra byte as a
+        // sentinel to detect responses that exceed our maximum size.
+        let mut data = String::new();
+        let bytes_read = rsp.take(store.max_response_size + 1).read_to_string(&mut data)?;
+        if bytes_read as u64 > store.max_response_size {
+            return Err(BrokerError::Custom("response exceeded the size limit".to_string()))
+        }
 
-            Ok(data)
+        // Cache the response for at least `expire_cache`, but honor longer `max-age`.
+        let seconds = max(store.expire_cache, max_age as usize);
+        store.client.set_ex(&key_str, &data, seconds)?;
 
-        }, |data| {
-            Ok(data)
-        }).and_then(|data| {
+        Ok(data)
 
-            from_str(&data).map_err(|_| {
-                BrokerError::Custom("failed to parse response as JSON".to_string())
-            })
+    }, |data| {
+        Ok(data)
+    }).and_then(|data| {
 
+        from_str(&data).map_err(|_| {
+            BrokerError::Custom("failed to parse response as JSON".to_string())
         })
 
-    }
+    })
+
 }

--- a/src/store_limits.rs
+++ b/src/store_limits.rs
@@ -1,0 +1,118 @@
+use std::error::Error;
+use std::str::FromStr;
+use std::time::{SystemTime, UNIX_EPOCH};
+use super::redis::{self, PipelineCommands};
+use super::error::BrokerResult;
+use super::store::Store;
+use super::serde::de::{Deserialize, Deserializer, Error as SerdeError};
+
+
+/// Represents a limit configuration.
+///
+/// Typically provided as a string `<name>:<max_count>:<timespan>:<granularity>`.
+#[derive(Clone,Debug)]
+pub struct LimitConfig {
+    /// A name for this config, appended to the Redis key.
+    pub name: String,
+    /// Maximum request count within the window before we refuse.
+    pub max_count: u64,
+    /// Timespan of the entire window, in seconds.
+    pub timespan: u64,
+    /// Timespan of a single bucket in the window, which defines the
+    /// time granularity with which we store request counts.
+    pub granularity: u64,
+}
+
+impl FromStr for LimitConfig {
+    type Err = String;
+    fn from_str(s: &str) -> Result<LimitConfig, String> {
+        let parts: Vec<&str> = s.split(":").collect();
+        if parts.len() != 4 {
+            return Err("Limit config must be 4 colon-separated parts".to_string());
+        }
+
+        let max_count = parts[1].parse::<u64>().map_err(|e| e.description().to_string())?;
+        let timespan = parts[2].parse::<u64>().map_err(|e| e.description().to_string())?;
+        let granularity = parts[3].parse::<u64>().map_err(|e| e.description().to_string())?;
+        if timespan % granularity != 0 {
+            return Err("Limit timespan must be a multiple of granularity".to_string());
+        }
+
+        Ok(LimitConfig {
+            name: parts[0].to_string(),
+            max_count: max_count,
+            timespan: timespan,
+            granularity: granularity,
+        })
+    }
+}
+
+impl Deserialize for LimitConfig {
+    fn deserialize<D: Deserializer>(deserializer: &mut D) -> Result<LimitConfig, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        LimitConfig::from_str(&s).map_err(|msg| D::Error::custom(msg))
+    }
+}
+
+
+/// Represents a Redis key.
+pub enum LimitKey<'a> {
+    Auth { email: &'a str },
+    AuthEmail { email: &'a str },
+}
+
+impl<'a> LimitKey<'a> {
+    fn to_string(&self, config: &LimitConfig) -> String {
+        match *self {
+            LimitKey::Auth { email } => {
+                format!("limit:auth:{}:{}", email, &config.name)
+            },
+            LimitKey::AuthEmail { email } => {
+                format!("limit:auth-email:{}:{}", email, &config.name)
+            },
+        }
+    }
+}
+
+
+/// Increment the given key, and test if the counter is within limits.
+///
+/// The Redis hash key represents a ring of counters. Each field in the hash counts requests
+/// for a small amount of time specified by the granularity. The sum of all hash fields then
+/// represents the count for the full configured timespan.
+///
+/// The hash has a TTL equal to the timespan, which is updated on every request, but individual
+/// hash fields must also expire. To accomplish this, we double the size of the hash, and clear
+/// the 'upcoming' half as we go. Thus, we'll never circle around to old counters before the
+/// key TTL expires.
+pub fn incr_and_test_limits(store: &Store, key: LimitKey, configs: &[LimitConfig]) -> BrokerResult<bool> {
+
+    let unixtime = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
+    let mut result = true;
+
+    for ref config in configs {
+        let key_str = key.to_string(config);
+
+        let num_buckets = config.timespan / config.granularity * 2;
+        let bucket = (unixtime / config.granularity) % num_buckets;
+
+        // Hash fields to delete, for the upcoming half of the counter ring.
+        let hdel_fields: Vec<u64> = (0..num_buckets / 2)
+            .map(|i| (bucket + 1 + i) % num_buckets)
+            .collect();
+
+        let (counts,): (Vec<u64>,) = redis::pipe()
+            .atomic()
+            .hincr(&key_str, bucket, 1).ignore()
+            .hdel(&key_str, hdel_fields).ignore()
+            .expire_at(&key_str, (unixtime + config.timespan) as usize).ignore()
+            .hvals(&key_str)
+            .query(&store.client)?;
+        let count = counts.iter().fold(0, |acc, val| acc + val);
+
+        // Aggregate result, but don't break (increment all counters)
+        result = result && count <= config.max_count;
+    }
+
+    Ok(result)
+}


### PR DESCRIPTION
First stab at an implementation of #70.

This is the third implementation option mentioned there, with I believe some small improvement. The details are explained here: https://github.com/portier/portier-broker/blob/d2374ae9ac2e0e3e306ce60fb5f666d8975ab406/src/store_limits.rs#L77-L86