### PR TITLE
Prevent whitespace from breaking template layout

### DIFF
--- a/tmpl/confirm_email.mustache
+++ b/tmpl/confirm_email.mustache
@@ -26,8 +26,7 @@
         <form id="form" action="/confirm" method="get">
           <input type="hidden" name="session" value="{{ session_id }}">
           <div class="entry">
-            <input type="text" name="code" maxlength="20" autofocus autocomplete="off" autocorrect="off" autocapitalize="off">
-            <button type="submit">Login</button>
+            <input type="text" name="code" maxlength="20" autofocus autocomplete="off" autocorrect="off" autocapitalize="off"><button type="submit">Login</button>
           </div>
         </form>
       </aside>


### PR DESCRIPTION
Note the space between the input widget and the submit button

---

![screen shot 2016-11-22 at 17 40 21](https://cloud.githubusercontent.com/assets/24193/20546466/dbda4bda-b0da-11e6-881b-2f6623e52841.png)
