### PR TITLE
Support for i18n

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 target
+lang/*.mo
 *.pem
 res/.well-known/*
 config.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,6 +5,8 @@ dependencies = [
  "docopt 0.6.86 (registry+https://github.com/rust-lang/crates.io-index)",
  "emailaddress 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gettext 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "iron 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lettre 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -53,6 +55,11 @@ dependencies = [
 [[package]]
 name = "bufstream"
 version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "byteorder"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -205,6 +212,20 @@ dependencies = [
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "gettext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "encoding 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "glob"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "hpack"
@@ -883,6 +904,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum bodyparser 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "07b171b407e583dc8f01011a713f20575a81ac60acecf3b8153012709aeb1fd6"
 "checksum bufstream 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7b48dbe2ff0e98fa2f03377d204a9637d3c9816cd431bfe05a8abbd0ea11d074"
+"checksum byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "96c8b41881888cc08af32d47ac4edd52bc7fa27fef774be47a92443756451304"
 "checksum chrono 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)" = "9213f7cd7c27e95c2b57c49f0e69b1ea65b27138da84a170133fd21b07659c00"
 "checksum conduit-mime-types 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "95ca30253581af809925ef68c2641cc140d6183f43e12e0af4992d53768bd7b8"
 "checksum cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0e3d6405328b6edb412158b3b7710e2634e23f3614b9bb1c412df7952489a626"
@@ -901,6 +923,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum error 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "a6e606f14042bb87cc02ef6a14db6c90ab92ed6f62d87e69377bc759fd7987cc"
 "checksum gcc 0.3.41 (registry+https://github.com/rust-lang/crates.io-index)" = "3689e1982a563af74960ae3a4758aa632bb8fd984cfc3cc3b60ee6109477ab6e"
 "checksum gdi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0912515a8ff24ba900422ecda800b52f4016a56251922d397c576bf92c690518"
+"checksum gettext 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "39c1d1d3c4d1630046ec3f3800a114008f98831497ad00231b83c00dd168f84a"
+"checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum hpack 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d2da7d3a34cf6406d9d700111b8eafafe9a251de41ae71d8052748259343b58"
 "checksum httparse 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a6e7a63e511f9edffbab707141fbb8707d1a3098615fb2adbd5769cdfcc9b17d"
 "checksum hyper 0.9.14 (registry+https://github.com/rust-lang/crates.io-index)" = "bcb3fc65554155980167fb821d05c7c66177f92464976c0b676a19d9e03387a7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ license = "MIT/Apache-2.0"
 name = "portier-broker"
 
 [build-dependencies]
+glob = "0.2.11"
 serde_codegen = "0.8.0"
 
 [dependencies]
@@ -36,3 +37,4 @@ time = "0.1.35"
 toml = { version = "0.2.1", default-features = false, features = ["serde"]}
 url = "1.2.4"
 urlencoded = "0.4.1"
+gettext = "0.2.0"

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -23,12 +23,14 @@ trap "docker rm -f ${container}" exit
 
 docker cp "${TARGET_DIR}/portier-broker" "${container}:/tmp/portier-broker"
 docker cp "tmpl" "${container}:/tmp/tmpl"
+docker cp "lang" "${container}:/tmp/lang"
 docker cp "res" "${container}:/tmp/res"
 docker start -ai "${container}" << END_CONTAINER_SCRIPT
 
 mkdir /tmp/build
 cd /tmp/build
-mv /tmp/portier-broker /tmp/tmpl /tmp/res ./
+mv /tmp/portier-broker /tmp/tmpl /tmp/lang /tmp/res ./
+rm lang/*.po
 
 mkdir certs
 cd certs

--- a/build.rs
+++ b/build.rs
@@ -3,16 +3,42 @@
 //
 // See https://serde.rs/codegen-stable.html for more information.
 
+extern crate glob;
 extern crate serde_codegen;
 
+use glob::glob;
 use std::env;
 use std::path::Path;
+use std::process::Command;
 
-pub fn main() {
+/// Build Serde generated code.
+pub fn build_serde() {
     let out_dir = env::var_os("OUT_DIR").expect("build.rs $OUT_DIR not specified");
 
     let src = Path::new("src/serde_types.in.rs");
     let dst = Path::new(&out_dir).join("serde_types.rs");
 
     serde_codegen::expand(&src, &dst).expect("serde codegen failed");
+}
+
+// Build gettext catalogs.
+pub fn build_gettext() {
+    for entry in glob("lang/*.po").expect("failed to glob gettext files") {
+        let src = entry.expect("failed to read glob entry");
+        let dst = src.with_extension("mo");
+
+        let mut cmd = Command::new("msgfmt");
+        cmd.arg(src).arg("-o").arg(dst);
+        println!("{:?}", cmd);
+
+        let status = cmd.status().expect("failed to execute msgfmt");
+        if !status.success() {
+            panic!("msgfmt exited with a failure status");
+        }
+    }
+}
+
+pub fn main() {
+    build_serde();
+    build_gettext();
 }

--- a/lang/de.po
+++ b/lang/de.po
@@ -1,0 +1,23 @@
+msgid "Finish logging in to"
+msgstr "Beende den Loginvorgang für"
+
+msgid "You received this email so that we may confirm your email address and finish your login to:"
+msgstr "Du hast diese Email erhalten, damit wir deine Emailadresse bestätigen und den Login beenden können:"
+
+msgid "Click here to login"
+msgstr "Klicke hier um dich einzuloggen"
+
+msgid "Alternatively, enter the following code on the login page:"
+msgstr "Alternativ kannst du diesen Code auf der Loginseite eingeben:"
+
+msgid "Confirm your address"
+msgstr "Bestätige deine Adresse"
+
+msgid "We've sent you an email to confirm your address."
+msgstr "Wir haben dir eine Email gesendet, um deine Adresse zu bestätigen."
+
+msgid "Use the link in that email to login to"
+msgstr "Benutze den Link in der Email für den Login bei"
+
+msgid "Alternatively, enter the code from the email to continue in this browser tab:"
+msgstr "Alternativ gebe in diesem Browsertab den in der Email stehenden Code ein:"

--- a/lang/en.po
+++ b/lang/en.po
@@ -1,0 +1,23 @@
+msgid "Finish logging in to"
+msgstr "Finish logging in to"
+
+msgid "You received this email so that we may confirm your email address and finish your login to:"
+msgstr "You received this email so that we may confirm your email address and finish your login to:"
+
+msgid "Click here to login"
+msgstr "Click here to login"
+
+msgid "Alternatively, enter the following code on the login page:"
+msgstr "Alternatively, enter the following code on the login page:"
+
+msgid "Confirm your address"
+msgstr "Confirm your address"
+
+msgid "We've sent you an email to confirm your address."
+msgstr "We've sent you an email to confirm your address."
+
+msgid "Use the link in that email to login to"
+msgstr "Use the link in that email to login to"
+
+msgid "Alternatively, enter the code from the email to continue in this browser tab:"
+msgstr "Alternatively, enter the code from the email to continue in this browser tab:"

--- a/lang/nl.po
+++ b/lang/nl.po
@@ -1,0 +1,23 @@
+msgid "Finish logging in to"
+msgstr "Login afronden voor"
+
+msgid "You received this email so that we may confirm your email address and finish your login to:"
+msgstr "U ontvangt deze email zodat wij uw email adres kunnen bevestigen en uw login kunnen afronden voor:"
+
+msgid "Click here to login"
+msgstr "Klik hier om in te loggen"
+
+msgid "Alternatively, enter the following code on the login page:"
+msgstr "Als alternatief kunt u ook de volgende code gebruiken op de login pagina:"
+
+msgid "Confirm your address"
+msgstr "Bevestig uw adres"
+
+msgid "We've sent you an email to confirm your address."
+msgstr "We hebben u een email gestuurd zodat wij uw adres kunnen bevestigen."
+
+msgid "Use the link in that email to login to"
+msgstr "Gebruik de link in die email om in te loggen op"
+
+msgid "Alternatively, enter the code from the email to continue in this browser tab:"
+msgstr "Als alternatief kunt u ook de code uit de email invoeren om in deze browser tab verder te gaan:"

--- a/src/handlers/oidc.rs
+++ b/src/handlers/oidc.rs
@@ -3,7 +3,7 @@ use email_bridge;
 use emailaddress::EmailAddress;
 use error::{BrokerError, BrokerResult};
 use iron::{Handler, IronResult, Plugin, Request, Response, Url};
-use iron::headers::{ContentType, Location};
+use iron::headers::{ContentType, Location, AcceptLanguage};
 use iron::method::Method;
 use iron::modifiers;
 use iron::status;
@@ -14,7 +14,6 @@ use super::{RedirectUri, handle_error, json_response};
 use super::super::store_limits::addr_limiter;
 use urlencoded::{UrlEncodedBody, UrlEncodedQuery};
 use validation::{valid_uri, only_origin, same_origin};
-
 
 /// Iron handler to return the OpenID Discovery document.
 ///
@@ -115,21 +114,36 @@ broker_handler!(Auth, |app, req| {
     }
 
     if app.providers.contains_key(&email_addr.domain.to_lowercase()) {
-
         // OIDC authentication. Redirect to the identity provider.
         let auth_url = oidc_bridge::request(app, email_addr, client_id, nonce, &parsed_redirect_uri)?;
         Ok(Response::with((status::SeeOther, modifiers::Header(Location(auth_url.to_string())))))
 
     } else {
+        // Determine the language catalog to use.
+        let mut catalog = &app.i18n.catalogs[0].1;
+        if let Some(accept) = req.headers.get::<AcceptLanguage>() {
+            'outer: for accept_language in accept.iter() {
+                for &(ref lang_tag, ref lang_catalog) in &app.i18n.catalogs {
+                    if lang_tag.matches(&accept_language.item) {
+                        catalog = lang_catalog;
+                        break 'outer;
+                    }
+                }
+            }
+        }
 
         // Email loop authentication. Render a message and form.
-        let session_id = email_bridge::request(app, email_addr, client_id, nonce, &parsed_redirect_uri)?;
+        let session_id = email_bridge::request(app, email_addr, client_id, nonce, &parsed_redirect_uri, &catalog)?;
+
         Ok(Response::with((status::Ok,
                            modifiers::Header(ContentType::html()),
                            app.templates.confirm_email.render(&[
                                ("client_id", &client_id),
                                ("session_id", &session_id),
+                               ("title", catalog.gettext("Confirm your address")),
+                               ("explanation", catalog.gettext("We've sent you an email to confirm your address.")),
+                               ("use", catalog.gettext("Use the link in that email to login to")),
+                               ("alternate", catalog.gettext("Alternatively, enter the code from the email to continue in this browser tab:")),
                            ]))))
-
     }
 });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ extern crate serde_json;
 extern crate time;
 extern crate url;
 extern crate urlencoded;
+extern crate gettext;
 
 use serde_json::builder::ObjectBuilder;
 use time::now_utc;

--- a/tmpl/confirm_email.mustache
+++ b/tmpl/confirm_email.mustache
@@ -3,25 +3,24 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Portier &ndash; Confirm your address</title>
+    <title>Portier &ndash; {{ title }}</title>
     <link rel="stylesheet" href="/static/style.css">
   </head>
   <body>
     <div class="container">
       <main>
         <h1 class="head">
-          We've sent you an email to confirm your address.
+          {{ explanation }}
         </h1>
         <p>
-          Use the link in that email to login to:<br>
+          {{ use }}<br>
           <em>{{ client_id }}</em>
         </p>
       </main>
       <hr />
       <aside>
         <p>
-          Alternatively, enter the code from the email
-          to continue in this browser tab:
+          {{ alternate }}
         </p>
         <form id="form" action="/confirm" method="get">
           <input type="hidden" name="session" value="{{ session_id }}">

--- a/tmpl/email_html.mustache
+++ b/tmpl/email_html.mustache
@@ -3,21 +3,20 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Portier &ndash; Finish logging in to {{ client_id }}</title>
+    <title>Portier &ndash; {{ title }} {{ client_id }}</title>
   </head>
   <body style="font: normal 1em/1.25em sans-serif">
     <div style="margin: 72px auto; max-width: 640px; text-align: center">
       <p style="margin: 24px; font:normal 1.25em sans-serif">
-        You received this email so that we may confirm your email address
-        and finish your login to: <em>{{ client_id }}</em>
+        {{ explanation }} <em>{{ client_id }}</em>
       </p>
       <p style="margin:24px">
         <a href="{{ link }}" style="display: inline-block; border:1px solid #23a1d9; border-radius: 4px; padding: 12px 24px; background: #36abdf; color:#fff; font-size: 1.25em; text-decoration: none">
-          Click here to login
+          {{ click }}
         </a>
       </p>
       <p style="margin:24px">
-        Alternatively, enter the following code on the login page:
+        {{ alternate }}
       </p>
       <p style="margin:24px;font: bold 1.25em monospace">
         {{ code }}


### PR DESCRIPTION
See the discussion in #116.

This implements i18n via gettext, using the rust gettext module from https://github.com/justinas/gettext. A simple makefile is provided to help create the .mo files which the program reads. Translations are given as variables into the templates, but are strings in the sourcecode – that is not perfect, but https://github.com/nickel-org/rust-mustache does not support the better approach of calling a function from within the template.

I tested this till the point of sending the email out.