### PR TITLE
Add cache headers.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,6 +200,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "gcc"
 version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -672,6 +680,7 @@ name = "staticfile"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "filetime 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "iron 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mount 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -921,6 +930,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum encoding_index_tests 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
 "checksum env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "15abd780e45b3ea4f76b4e9a26ff4843258dd8a3eed2775a0e7368c2e7936c2f"
 "checksum error 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "a6e606f14042bb87cc02ef6a14db6c90ab92ed6f62d87e69377bc759fd7987cc"
+"checksum filetime 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "5363ab8e4139b8568a6237db5248646e5a8a2f89bd5ccb02092182b11fd3e922"
 "checksum gcc 0.3.41 (registry+https://github.com/rust-lang/crates.io-index)" = "3689e1982a563af74960ae3a4758aa632bb8fd984cfc3cc3b60ee6109477ab6e"
 "checksum gdi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0912515a8ff24ba900422ecda800b52f4016a56251922d397c576bf92c690518"
 "checksum gettext 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "39c1d1d3c4d1630046ec3f3800a114008f98831497ad00231b83c00dd168f84a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ router = "0.4.0"
 rustc-serialize = "0.3.22"
 serde = "0.8.21"
 serde_json = "0.8.4"
-staticfile = "0.3.1"
+staticfile = { version = "0.3.1", features = ["cache"] }
 time = "0.1.35"
 toml = { version = "0.2.1", default-features = false, features = ["serde"]}
 url = "1.2.4"

--- a/README.rst
+++ b/README.rst
@@ -60,6 +60,16 @@ public_url      BROKER_PUBLIC_URL      (none)
 allowed_origins BROKER_ALLOWED_ORIGINS (none (unrestricted))
 =============== ====================== =====================
 
+**[headers] section:**
+
+=============== ==================== ================
+``config.toml`` Environment Variable Default
+=============== ==================== ================
+static_ttl      BROKER_STATIC_TTL    604800 (1 week)
+discovery_ttl   BROKER_DISCOVERY_TTL 604800 (1 week)
+keys_ttl        BROKER_KEYS_TTL      86400 (1 day)
+=============== ==================== ================
+
 **[crypto] section:**
 
 =============== ==================== ================

--- a/config.toml.dist
+++ b/config.toml.dist
@@ -9,6 +9,15 @@ public_url =
 allowed_origins = 
 
 
+[headers]
+# Static resources cache max-age we indicate to clients - Default: 604800 (1 week)
+static_ttl = 604800
+# Discovery JSON cache max-age we indicate to clients - Default: 604800 (1 week)
+discovery_ttl = 604800
+# Keys JSON cache max-age we indicate to clients - Default: 86400 (1 day)
+keys_ttl = 86400
+
+
 [crypto]
 # Duration that id_tokens are valid for - Default: 600 (10 minutes)
 token_ttl = 600

--- a/src/config.rs
+++ b/src/config.rs
@@ -155,6 +155,9 @@ pub struct Config {
     pub listen_port: u16,
     pub public_url: String,
     pub allowed_origins: Option<Vec<String>>,
+    pub static_ttl: u32,
+    pub discovery_ttl: u32,
+    pub keys_ttl: u32,
     pub token_ttl: u16,
     pub keys: Vec<crypto::NamedKey>,
     pub store: store::Store,
@@ -176,6 +179,9 @@ pub struct ConfigBuilder {
     pub listen_port: u16,
     pub public_url: Option<String>,
     pub allowed_origins: Option<Vec<String>>,
+    pub static_ttl: u32,
+    pub discovery_ttl: u32,
+    pub keys_ttl: u32,
     pub token_ttl: u16,
     pub keyfiles: Vec<String>,
     pub keytext: Option<String>,
@@ -244,6 +250,9 @@ impl ConfigBuilder {
             listen_port: 3333,
             public_url: None,
             allowed_origins: None,
+            static_ttl: 604800,
+            discovery_ttl: 604800,
+            keys_ttl: 86400,
             token_ttl: 600,
             keyfiles: Vec::new(),
             keytext: None,
@@ -273,6 +282,12 @@ impl ConfigBuilder {
             if let Some(val) = table.listen_port { self.listen_port = val; }
             self.public_url = table.public_url.or_else(|| self.public_url.clone());
             if let Some(val) = table.allowed_origins { self.allowed_origins = Some(val) };
+        }
+
+        if let Some(table) = toml_config.headers {
+            if let Some(val) = table.static_ttl { self.static_ttl = val; }
+            if let Some(val) = table.discovery_ttl { self.discovery_ttl = val; }
+            if let Some(val) = table.keys_ttl { self.keys_ttl = val; }
         }
 
         if let Some(table) = toml_config.crypto {
@@ -348,6 +363,10 @@ impl ConfigBuilder {
         if let Some(val) = env_config.broker_port { self.listen_port = val; }
         if let Some(val) = env_config.broker_public_url { self.public_url = Some(val); }
         if let Some(val) = env_config.broker_allowed_origins { self.allowed_origins = Some(val); }
+
+        if let Some(val) = env_config.broker_static_ttl { self.static_ttl = val; }
+        if let Some(val) = env_config.broker_discovery_ttl { self.discovery_ttl = val; }
+        if let Some(val) = env_config.broker_keys_ttl { self.keys_ttl = val; }
 
         if let Some(val) = env_config.broker_token_ttl { self.token_ttl = val; }
         if let Some(val) = env_config.broker_keyfiles { self.keyfiles = val; }
@@ -429,6 +448,9 @@ impl ConfigBuilder {
             listen_port: self.listen_port,
             public_url: self.public_url.expect("no public url configured"),
             allowed_origins: self.allowed_origins,
+            static_ttl: self.static_ttl,
+            discovery_ttl: self.discovery_ttl,
+            keys_ttl: self.keys_ttl,
             token_ttl: self.token_ttl,
             keys: keys,
             store: store,
@@ -456,6 +478,10 @@ impl EnvConfig {
             broker_port: env::var("BROKER_PORT").ok().and_then(|x| x.parse().ok()),
             broker_public_url: env::var("BROKER_PUBLIC_URL").ok(),
             broker_allowed_origins: env::var("BROKER_ALLOWED_ORIGINS").ok().map(|x| x.split(',').map(|x| x.to_string()).collect()),
+
+            broker_static_ttl: env::var("BROKER_STATIC_TTL").ok().and_then(|x| x.parse().ok()),
+            broker_discovery_ttl: env::var("BROKER_DISCOVERY_TTL").ok().and_then(|x| x.parse().ok()),
+            broker_keys_ttl: env::var("BROKER_KEYS_TTL").ok().and_then(|x| x.parse().ok()),
 
             broker_token_ttl: env::var("BROKER_TOKEN_TTL").ok().and_then(|x| x.parse().ok()),
             broker_keyfiles: env::var("BROKER_KEYFILES").ok().map(|x| x.split(',').map(|x| x.to_string()).collect()),

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,5 @@
+#![allow(unknown_lints, cyclomatic_complexity)]
+
 extern crate serde;
 extern crate toml;
 

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -2,7 +2,7 @@ use config::Config;
 use error::{BrokerResult, BrokerError};
 use hyper;
 use iron::{IronError, IronResult, Request, Response, Url};
-use iron::headers::ContentType;
+use iron::headers::{ContentType, CacheControl, CacheDirective};
 use iron::modifiers;
 use iron::status;
 use iron::typemap;
@@ -164,10 +164,14 @@ fn handle_error(app: &Config, req: &mut Request, err: BrokerError) -> IronResult
 ///
 /// Serializes the argument value to JSON and returns a HTTP 200 response
 /// code with the serialized JSON as the body.
-fn json_response(obj: &Value) -> BrokerResult<Response> {
+fn json_response(obj: &Value, max_age: u32) -> BrokerResult<Response> {
     let content = serde_json::to_string(&obj).expect("unable to coerce JSON Value into string");
     Ok(Response::with((status::Ok,
                        modifiers::Header(ContentType::json()),
+                       modifiers::Header(CacheControl(vec![
+                           CacheDirective::Public,
+                           CacheDirective::MaxAge(max_age),
+                       ])),
                        content)))
 }
 

--- a/src/handlers/oidc.rs
+++ b/src/handlers/oidc.rs
@@ -20,7 +20,7 @@ use validation::{valid_uri, only_origin, same_origin};
 /// Most of this is hard-coded for now, although the URLs are constructed by
 /// using the base URL as configured in the `public_url` configuration value.
 broker_handler!(Discovery, |app, _req| {
-    json_response(&ObjectBuilder::new()
+    let obj = ObjectBuilder::new()
         .insert("issuer", &app.public_url)
         .insert("authorization_endpoint",
                 format!("{}/auth", app.public_url))
@@ -33,7 +33,8 @@ broker_handler!(Discovery, |app, _req| {
         .insert("grant_types_supported", vec!["implicit"])
         .insert("subject_types_supported", vec!["public"])
         .insert("id_token_signing_alg_values_supported", vec!["RS256"])
-        .build())
+        .build();
+    json_response(&obj, app.discovery_ttl)
 });
 
 
@@ -48,9 +49,10 @@ broker_handler!(KeySet, |app, _req| {
     for key in &app.keys {
         keys = keys.push(key.public_jwk())
     }
-    json_response(&ObjectBuilder::new()
-                      .insert("keys", keys.build())
-                      .build())
+    let obj = ObjectBuilder::new()
+        .insert("keys", keys.build())
+        .build();
+    json_response(&obj, app.keys_ttl)
 });
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ use std::error::Error;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::path::Path;
+use std::time::Duration;
 
 
 /// Defines the program's version, as set by Cargo at compile time.
@@ -85,12 +86,13 @@ fn main() {
         callback:  get  "/callback" => broker::handlers::oauth2::Callback::new(&app),
 
         // Lastly, fall back to trying to serve static files out of ./res/
-        static:    get  "/*" => staticfile::Static::new(Path::new("./res/")),
+        static:    get  "/*" => staticfile::Static::new(Path::new("./res/"))
+                                    .cache(Duration::from_secs(app.static_ttl as u64)),
     };
 
     let mut chain = Chain::new(router);
     chain.link_before(broker::middleware::LogRequest);
-    chain.link_after(broker::middleware::SecurityHeaders);
+    chain.link_after(broker::middleware::CommonHeaders);
 
     let ipaddr = std::net::IpAddr::from_str(&app.listen_ip).expect("Unable to parse listen IP address");
     let socket = std::net::SocketAddr::new(ipaddr, app.listen_port);

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -2,4 +2,4 @@ mod logging;
 pub use self::logging::LogRequest;
 
 mod headers;
-pub use self::headers::SecurityHeaders;
+pub use self::headers::CommonHeaders;

--- a/src/serde_types.in.rs
+++ b/src/serde_types.in.rs
@@ -7,6 +7,7 @@
 #[derive(Clone,Debug,Deserialize)]
 struct TomlConfig {
     server: Option<TomlServerTable>,
+    headers: Option<TomlHeadersTable>,
     crypto: Option<TomlCryptoTable>,
     redis: Option<TomlRedisTable>,
     smtp: Option<TomlSmtpTable>,
@@ -20,6 +21,13 @@ struct TomlServerTable {
     listen_port: Option<u16>,
     public_url: Option<String>,
     allowed_origins: Option<Vec<String>>,
+}
+
+#[derive(Clone,Debug,Deserialize)]
+struct TomlHeadersTable {
+    static_ttl: Option<u32>,
+    discovery_ttl: Option<u32>,
+    keys_ttl: Option<u32>,
 }
 
 #[derive(Clone,Debug,Deserialize)]
@@ -70,6 +78,9 @@ struct EnvConfig {
     broker_port: Option<u16>,
     broker_public_url: Option<String>,
     broker_allowed_origins: Option<Vec<String>>,
+    broker_static_ttl: Option<u32>,
+    broker_discovery_ttl: Option<u32>,
+    broker_keys_ttl: Option<u32>,
     broker_token_ttl: Option<u16>,
     broker_keyfiles: Option<Vec<String>>,
     broker_keytext: Option<String>,


### PR DESCRIPTION
Fixes #41.

The approach here is to just set `Cache-Control: no-cache, no-store` for everything, except when overridden explicitly. The overrides are for static files, discovery and keys, each having a config var.

The discovery and keys resources don't set Last-Modified and Etag. I feel like it's more trouble than it's worth?