### PR TITLE
Adjust supported claims to mirror spec

### DIFF
--- a/src/handlers/auth.rs
+++ b/src/handlers/auth.rs
@@ -24,7 +24,7 @@ pub fn discovery(ctx_handle: &ContextHandle) -> HandlerResult {
         "authorization_endpoint": format!("{}/auth", ctx.app.public_url),
         "jwks_uri": format!("{}/keys.json", ctx.app.public_url),
         "scopes_supported": vec!["openid", "email"],
-        "claims_supported": vec!["aud", "email", "email_verified", "exp", "iat", "iss", "sub"],
+        "claims_supported": vec!["iss", "aud", "exp", "iat", "email"],
         "response_types_supported": vec!["id_token"],
         "response_modes_supported": vec!["form_post"],
         "grant_types_supported": vec!["implicit"],


### PR DESCRIPTION
Reflects this spec: https://github.com/portier/portier.github.io/pull/33

Notably, stop announcing `email_verified`, because we have been setting it incorrectly all this time, and probably want to rid ourselves of it.

Also drops `sub`, which duplicates `email` in our case. This also brings things in line with the IdP side.

I figure we shouldn't add `email_original`, because it's unofficial. Apparently, nobody announces `nonce` either, so it is omitted here as well.

These are still present in the token, we just stop announcing them in config.