### PR TITLE
document and coerce redis connection url

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -101,7 +101,7 @@ keytext         BROKER_KEYTEXT       (none)
 =============== ==================== ================
 ``config.toml`` Environment Variable Default
 =============== ==================== ================
-url             BROKER_REDIS_URL     (none)
+url             BROKER_REDIS_URL     (none) (example: redis://localhost:6379)
 session_ttl     BROKER_SESSION_TTL   900 (15 minutes)
 cache_ttl       BROKER_CACHE_TTL     3600 (1 hour)
 =============== ==================== ================

--- a/config.toml.dist
+++ b/config.toml.dist
@@ -28,7 +28,7 @@ keytext =
 
 
 [redis]
-# Redis connection URL - Default: (mandatory, CHANGE THIS)
+# Redis connection URL - Default: (mandatory, CHANGE THIS) (example: redis://localhost, redis://localhost:6379/0)
 url =
 # Time that users have to complete authentication - Default: 900 (15 minutes)
 session_ttl = 900


### PR DESCRIPTION
1. Documents an example redis connection URL in the README.
2. Additionally notes it in the `config.toml.dist`
3. Adds some code to coerce the url that others might be used to having work for redis server urls.