### PR TITLE
pass the 'state' parameter back in the implicit flow

### DIFF
--- a/src/bridges/mod.rs
+++ b/src/bridges/mod.rs
@@ -21,7 +21,7 @@ pub fn complete_auth(ctx: &Context, email: &EmailAddress) -> BrokerResult<Respon
     ctx.app.store.remove_session(&ctx.session_id)?;
     let aud = data.return_params.redirect_uri.origin().ascii_serialization();
     let jwt = crypto::create_jwt(&ctx.app, &data.email, email, &aud, &data.nonce);
-    Ok(return_to_relier(ctx, &[("id_token", &jwt)]))
+    Ok(return_to_relier(ctx, &[("id_token", &jwt),("state", &data.return_params.state)]))
 }
 
 

--- a/src/handlers/auth.rs
+++ b/src/handlers/auth.rs
@@ -71,6 +71,7 @@ pub fn auth(ctx_handle: &ContextHandle) -> HandlerResult {
     let client_id = try_get_input_param!(params, "client_id");
     let response_mode = try_get_input_param!(params, "response_mode", "fragment".to_owned());
     let response_errors = try_get_input_param!(params, "response_errors", "true".to_owned());
+    let state = try_get_input_param!(params, "state", "".to_owned());
 
     let redirect_uri = match parse_redirect_uri(&redirect_uri, "redirect_uri") {
         Ok(url) => url,
@@ -98,7 +99,7 @@ pub fn auth(ctx_handle: &ContextHandle) -> HandlerResult {
 
     // Per the OAuth2 spec, we may redirect to the RP once we have validated client_id and
     // redirect_uri. In our case, this means we make redirect_uri available to error handling.
-    ctx.return_params = Some(ReturnParams { redirect_uri, response_mode, response_errors });
+    ctx.return_params = Some(ReturnParams { redirect_uri, response_mode, response_errors, state });
 
     if let Some(ref whitelist) = ctx.app.allowed_origins {
         if !whitelist.contains(&client_id) {

--- a/src/http.rs
+++ b/src/http.rs
@@ -76,6 +76,7 @@ pub struct ReturnParams {
     pub redirect_uri: Url,
     pub response_mode: ResponseMode,
     pub response_errors: bool,
+    pub state: String,
 }
 
 


### PR DESCRIPTION
Return the `state` back to the initiator when returning the `id_token`. Fixes #170.