### PR TITLE
Fixes for the login form

### DIFF
--- a/lang/de.po
+++ b/lang/de.po
@@ -54,3 +54,9 @@ msgstr "Dein Loginversuch brauchte wohl zu lange, oder du bist einem alten Link 
 
 msgid "Technical description"
 msgstr "Technische Beschreibung"
+
+msgid "Login with your email address."
+msgstr "Mit deiner E-Mail-Adresse einloggen."
+
+msgid "Please specify the email you wish to use to login with"
+msgstr "Bitte gebe die E-Mail-Adresse an, mit der du dich einloggen willst"

--- a/lang/en.po
+++ b/lang/en.po
@@ -60,4 +60,3 @@ msgstr "Login with your email address."
 
 msgid "Please specify the email you wish to use to login with"
 msgstr "Please specify the email you wish to use to login with"
-

--- a/lang/nl.po
+++ b/lang/nl.po
@@ -54,3 +54,9 @@ msgstr "Uw inlogpoging heeft wellicht te lang geduurd, of u probeerde een oude l
 
 msgid "Technical description"
 msgstr "Technische omschrijving"
+
+msgid "Login with your email address."
+msgstr "Login met uw email adres."
+
+msgid "Please specify the email you wish to use to login with"
+msgstr "Vul het email adres in waarmee u wilt inloggen op"

--- a/src/handlers/auth.rs
+++ b/src/handlers/auth.rs
@@ -129,7 +129,7 @@ pub fn auth(ctx_handle: &ContextHandle) -> HandlerResult {
             // TODO: catalog/localization?
             .insert_str("display_origin", display_origin)
             .insert_str("title", catalog.gettext("Finish logging in to"))
-            .insert_str("explanation", catalog.gettext("Login with your email."))
+            .insert_str("explanation", catalog.gettext("Login with your email address."))
             .insert_str("use", catalog.gettext("Please specify the email you wish to use to login with"))
             .insert_vec("params", |mut builder| {
                 for param in &original_params {

--- a/src/handlers/auth.rs
+++ b/src/handlers/auth.rs
@@ -122,13 +122,13 @@ pub fn auth(ctx_handle: &ContextHandle) -> HandlerResult {
 
     let login_hint = try_get_input_param!(params, "login_hint", "".to_string());
     if login_hint == "" {
+        let display_origin = redirect_uri_.origin().unicode_serialization();
+
         let catalog = ctx.catalog();
         let data = mustache::MapBuilder::new()
             // TODO: catalog/localization?
-            .insert_str("display_origin", redirect_uri_.to_string())
+            .insert_str("display_origin", display_origin)
             .insert_str("title", catalog.gettext("Finish logging in to"))
-            .insert_str("form_action", format!("{}/auth", &ctx.app.public_url))
-            .insert_str("method", ctx.method.to_string())
             .insert_str("explanation", catalog.gettext("Login with your email."))
             .insert_str("use", catalog.gettext("Please specify the email you wish to use to login with"))
             .insert_vec("params", |mut builder| {

--- a/src/http.rs
+++ b/src/http.rs
@@ -238,11 +238,11 @@ impl HyperService for Service {
             // Determine the language catalog to use.
             let mut catalog_idx = 0;
             if let Some(&AcceptLanguage(ref list)) = headers.get() {
-                for entry in list {
+                'lang: for entry in list {
                     for (idx, &(ref tag, _)) in app.i18n.catalogs.iter().enumerate() {
                         if tag.matches(&entry.item) {
                             catalog_idx = idx;
-                            break;
+                            break 'lang;
                         }
                     }
                 }

--- a/tmpl/login_hint.mustache
+++ b/tmpl/login_hint.mustache
@@ -18,7 +18,7 @@
         </p>
         <hr />
         <div class="entry">
-          <form id="form" action="{{ form_action }}" method="{{ method }}">
+          <form id="form" action="/auth" method="post">
             {{# params }}
               <input type="hidden" name="{{ name }}" value="{{ value }}">
             {{/ params }}


### PR DESCRIPTION
I apparently never created a PR for these fixes I had lying around locally. These are for the form displayed when no `login_hint` is provided.

@onli Maybe you can also add the two missing German translations?