### PR TITLE
Validate `scope`, fixes #180

### DIFF
--- a/src/handlers/auth.rs
+++ b/src/handlers/auth.rs
@@ -9,6 +9,7 @@ use futures_util::future::{self, Either};
 use http::Method;
 use log::info;
 use serde_json::{from_value, json, Value};
+use std::collections::HashSet;
 use std::time::Duration;
 
 /// Request handler to return the OpenID Discovery document.
@@ -107,6 +108,15 @@ pub async fn auth(ctx: &mut Context) -> HandlerResult {
     if try_get_input_param!(params, "response_type") != "id_token" {
         return Err(BrokerError::Input(
             "unsupported response_type, only id_token is supported".to_owned(),
+        ));
+    }
+
+    let scope = try_get_input_param!(params, "scope");
+    let mut scope_set: HashSet<&str> = scope.split(' ').collect();
+    scope_set.remove("email");
+    if !scope_set.remove("openid") || !scope_set.is_empty() {
+        return Err(BrokerError::Input(
+            "unsupported scope, must contain 'openid' and optionally 'email'".to_owned(),
         ));
     }
 

--- a/tests/e2e/main.js
+++ b/tests/e2e/main.js
@@ -15,7 +15,7 @@ const main = async () => {
     broker = runBroker();
     relyingParty = runRelyingParty();
     driver = await createDriver();
-    await runTests(driver);
+    await runTests({ broker, relyingParty, driver });
   } finally {
     if (driver) {
       await driver.quit().catch(err => {


### PR DESCRIPTION
This makes it so `openid` is required, and `email` is optional, but provided in the id_token claims regardless. Any other unknown scopes result in an error.