### PR TITLE
Convert E2E tests to TypeScript

### DIFF
--- a/tests/e2e/main.ts
+++ b/tests/e2e/main.ts
@@ -2,19 +2,22 @@
 
 // Entry point for the test runner.
 
-const { Builder } = require("selenium-webdriver");
-const chrome = require("selenium-webdriver/chrome");
-const firefox = require("selenium-webdriver/firefox");
+import { Builder, WebDriver } from "selenium-webdriver";
+import chrome from "selenium-webdriver/chrome";
+import firefox from "selenium-webdriver/firefox";
 
-const createMailbox = require("./src/mailbox");
-const createBroker = require("./src/broker");
-const createRelyingParty = require("./src/relying-party");
-const createTests = require("./src/tests");
+import createMailbox, { Mailbox } from "./src/mailbox";
+import createBroker, { Broker } from "./src/broker";
+import createRelyingParty, { RelyingParty } from "./src/relying-party";
+import createTests from "./src/tests";
 
-const { HEADLESS } = require("./src/env");
+import { HEADLESS } from "./src/env";
 
 const main = async () => {
-  let mailbox, broker, relyingParty, driver;
+  let mailbox: Mailbox | undefined,
+    broker: Broker | undefined,
+    relyingParty: RelyingParty | undefined,
+    driver: WebDriver | undefined;
   try {
     mailbox = createMailbox();
     broker = createBroker({ mailbox });
@@ -23,13 +26,13 @@ const main = async () => {
     await createTests({ mailbox, broker, relyingParty, driver });
   } finally {
     if (driver) {
-      await driver.quit().catch(err => {
+      await driver.quit().catch((err) => {
         console.error("Error while stopping Selenium:");
         console.error(err);
       });
     }
     if (relyingParty) {
-      relyingParty.destroy();
+      relyingParty.destroy!();
     }
     if (broker) {
       broker.destroy();
@@ -40,7 +43,7 @@ const main = async () => {
   }
 };
 
-const createDriver = async browser => {
+const createDriver = async () => {
   const windowSize = { width: 800, height: 600 };
   const firefoxOptions = new firefox.Options().windowSize(windowSize);
   const chromeOptions = new chrome.Options().windowSize(windowSize);
@@ -55,7 +58,7 @@ const createDriver = async browser => {
   return builder.build();
 };
 
-main().catch(err => {
+main().catch((err) => {
   console.error(err);
   process.exitCode = 1;
 });

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -3,13 +3,27 @@
   "version": "0.0.0",
   "license": "(MIT OR Apache-2.0)",
   "private": true,
+  "scripts": {
+    "test": "ts-node main.ts",
+    "test:chrome": "cross-env SELENIUM_BROWSER=chrome npm test",
+    "test:firefox": "cross-env SELENIUM_BROWSER=firefox npm test"
+  },
   "dependencies": {
+    "@types/body-parser": "^1.19.0",
+    "@types/express": "^4.17.7",
+    "@types/mailparser": "^2.7.3",
+    "@types/node-fetch": "^2.5.7",
+    "@types/selenium-webdriver": "^4.0.9",
+    "@types/smtp-server": "^3.5.4",
     "body-parser": "^1.19.0",
+    "cross-env": "^7.0.2",
     "express": "^4.17.1",
     "mailparser": "^2.7.7",
     "node-fetch": "^2.6.0",
     "portier": "^0.4.1",
     "selenium-webdriver": "^4.0.0-alpha.5",
-    "smtp-server": "^3.6.0"
+    "smtp-server": "^3.6.0",
+    "ts-node": "^8.10.2",
+    "typescript": "^3.9.6"
   }
 }

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -20,7 +20,7 @@
     "express": "^4.17.1",
     "mailparser": "^2.7.7",
     "node-fetch": "^2.6.0",
-    "portier": "^0.4.1",
+    "portier": "^0.4.2",
     "selenium-webdriver": "^4.0.0-alpha.5",
     "smtp-server": "^3.6.0",
     "ts-node": "^8.10.2",

--- a/tests/e2e/src/env.ts
+++ b/tests/e2e/src/env.ts
@@ -7,17 +7,24 @@ const {
   TEST_KEY_MANAGER = "manual",
   TEST_MAILER = "smtp",
   SELENIUM_BROWSER = "firefox",
-  HEADLESS = "1"
+  HEADLESS = "1",
 } = process.env;
 
-module.exports = {
+// Re-apply to environment, mostly for Selenium.
+Object.assign(process.env, {
   RUST_LOG,
   TEST_STORE,
   TEST_KEY_MANAGER,
   TEST_MAILER,
   SELENIUM_BROWSER,
-  HEADLESS
-};
+  HEADLESS,
+});
 
-// Re-apply to environment, mostly for Selenium.
-Object.assign(process.env, module.exports);
+export {
+  RUST_LOG,
+  TEST_STORE,
+  TEST_KEY_MANAGER,
+  TEST_MAILER,
+  SELENIUM_BROWSER,
+  HEADLESS,
+};

--- a/tests/e2e/src/relying-party.ts
+++ b/tests/e2e/src/relying-party.ts
@@ -1,21 +1,28 @@
 // Starts a simple relying party implementation.
 
-const express = require("express");
-const formParser = require("body-parser").urlencoded({ extended: false });
-const { EventEmitter } = require("events");
-const { PortierClient } = require("portier");
+import express from "express";
+import bodyParser from "body-parser";
+import { EventEmitter } from "events";
+import { PortierClient } from "portier";
 
-module.exports = () => {
-  const instance = new EventEmitter();
+const formParser = bodyParser.urlencoded({ extended: false });
+
+export type RelyingParty = EventEmitter & {
+  portier?: PortierClient;
+  destroy?: () => void;
+};
+
+export default (): RelyingParty => {
+  const instance: RelyingParty = new EventEmitter();
 
   const portier = new PortierClient({
     broker: "http://localhost:44133",
-    redirectUri: "http://localhost:44180/verify"
+    redirectUri: "http://localhost:44180/verify",
   });
 
   const app = express();
 
-  app.get("/", (req, res) => {
+  app.get("/", (_req, res) => {
     res.type("html").end(`
       <title>RP: Login</title>
       <form method="post" action="/auth">

--- a/tests/e2e/tsconfig.json
+++ b/tests/e2e/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "module": "commonjs",
+    "lib": ["ES2017"],
+    "declaration": true,
+    "rootDir": "src",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true
+  }
+}


### PR DESCRIPTION
This PR converts the E2E tests to TypeScript, to be consistent with `portier-node`.

(If this warning is present, this PR depends on https://github.com/portier/portier-node/pull/9. Until that's merged and released on npm, CI likely won't pass since TypeScript is going to fail to compile.)

- Converted CommonJS imports/exports to ES6
- Added new `npm run test:chrome` and `npm run test:firefox` scripts to make it easier to run browser tests on Windows
- Converted all files to TypeScript
- Updated files to match output from latest version of Prettier