### PR TITLE
Add support for E2E testing of HTTP mailers

### DIFF
--- a/src/agents/mailer/postmark.rs
+++ b/src/agents/mailer/postmark.rs
@@ -41,10 +41,6 @@ impl Agent for PostmarkMailer {}
 
 impl Handler<SendMail> for PostmarkMailer {
     fn handle(&mut self, message: SendMail, cx: Context<Self, SendMail>) {
-        // If using the test token, print the email text body to stderr.
-        // This is here for our test suite, but maybe useful in general.
-        let is_test_request = self.token == "POSTMARK_API_TEST";
-
         let body = serde_json::to_vec(&json!({
             "From": &self.from,
             "To": message.to,
@@ -78,11 +74,6 @@ impl Handler<SendMail> for PostmarkMailer {
                 }
             };
             if response.error_code == 0 {
-                if is_test_request {
-                    eprintln!("-----BEGIN EMAIL TEXT BODY-----");
-                    eprintln!("{}", message.text_body);
-                    eprintln!("-----END EMAIL TEXT BODY-----");
-                }
                 true
             } else {
                 log::error!("Postmark returned error code {}", response.error_code);

--- a/src/agents/mailer/postmark.rs
+++ b/src/agents/mailer/postmark.rs
@@ -16,6 +16,7 @@ struct PostmarkResponse {
 pub struct PostmarkMailer {
     fetcher: Addr<FetchAgent>,
     token: String,
+    api: String,
     from: String,
 }
 
@@ -23,12 +24,14 @@ impl PostmarkMailer {
     pub fn new(
         fetcher: Addr<FetchAgent>,
         token: String,
+        api: String,
         from_address: &EmailAddress,
         from_name: &str,
     ) -> Self {
         PostmarkMailer {
             fetcher,
             token,
+            api,
             from: format!("{} <{}>", from_name, from_address),
         }
     }
@@ -51,7 +54,7 @@ impl Handler<SendMail> for PostmarkMailer {
         }))
         .expect("Could not build Postmark request JSON body");
 
-        let request = Request::post("https://api.postmarkapp.com/email")
+        let request = Request::post(&self.api)
             .header("Accept", "application/json")
             .header("Content-Type", "application/json")
             .header("X-Postmark-Server-Token", &self.token)

--- a/src/config/env.rs
+++ b/src/config/env.rs
@@ -43,7 +43,6 @@ pub struct EnvConfig {
     sendmail_command: Option<String>,
 
     postmark_token: Option<String>,
-
     postmark_api: Option<String>,
 
     limits: Option<Vec<LimitConfig>>,

--- a/src/config/env.rs
+++ b/src/config/env.rs
@@ -44,6 +44,8 @@ pub struct EnvConfig {
 
     postmark_token: Option<String>,
 
+    postmark_api: Option<String>,
+
     limits: Option<Vec<LimitConfig>>,
     limit_per_email: Option<LegacyLimitPerEmail>,
 
@@ -165,6 +167,10 @@ impl EnvConfig {
 
         if let Some(val) = parsed.postmark_token {
             builder.postmark_token = Some(val);
+        }
+
+        if let Some(val) = parsed.postmark_api {
+            builder.postmark_api = val;
         }
 
         if let Some(val) = parsed.limits {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -320,7 +320,6 @@ pub struct ConfigBuilder {
     pub sendmail_command: Option<String>,
 
     pub postmark_token: Option<String>,
-
     pub postmark_api: String,
 
     pub limits: Vec<LimitConfig>,
@@ -371,7 +370,6 @@ impl ConfigBuilder {
             sendmail_command: None,
 
             postmark_token: None,
-
             postmark_api: "https://api.postmarkapp.com/email".to_owned(),
 
             limits: [

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -190,7 +190,7 @@ enum MailerConfig {
     #[cfg(feature = "lettre_sendmail")]
     LettreSendmail { command: String },
     #[cfg(feature = "postmark")]
-    Postmark { token: String },
+    Postmark { token: String, api: String },
 }
 
 impl MailerConfig {
@@ -200,6 +200,7 @@ impl MailerConfig {
         #[allow(unused)] smtp_password: Option<String>,
         sendmail_command: Option<String>,
         postmark_token: Option<String>,
+        postmark_api: String,
     ) -> Result<Self, ConfigError> {
         match (smtp_server, sendmail_command, postmark_token) {
             #[cfg(feature = "lettre_smtp")]
@@ -230,7 +231,7 @@ impl MailerConfig {
             }
 
             #[cfg(feature = "postmark")]
-            (None, None, Some(token)) => Ok(MailerConfig::Postmark { token }),
+            (None, None, Some(token)) => Ok(MailerConfig::Postmark { token, api: postmark_api }),
             #[cfg(not(feature = "postmark"))]
             (None, None, Some(_)) => {
                 Err("Postmark mailer requested, but this build does not support it.".into())
@@ -271,10 +272,11 @@ impl MailerConfig {
                 Box::new(spawn_agent(mailer).await)
             }
             #[cfg(feature = "postmark")]
-            MailerConfig::Postmark { token } => {
+            MailerConfig::Postmark { token, api } => {
                 let mailer = agents::PostmarkMailer::new(
                     params.fetcher,
                     token,
+                    api,
                     &params.from_address,
                     &params.from_name,
                 );
@@ -318,6 +320,8 @@ pub struct ConfigBuilder {
     pub sendmail_command: Option<String>,
 
     pub postmark_token: Option<String>,
+
+    pub postmark_api: String,
 
     pub limits: Vec<LimitConfig>,
 
@@ -367,6 +371,8 @@ impl ConfigBuilder {
             sendmail_command: None,
 
             postmark_token: None,
+
+            postmark_api: "https://api.postmarkapp.com/email".to_owned(),
 
             limits: [
                 "ip:50/s",
@@ -437,6 +443,7 @@ impl ConfigBuilder {
             self.smtp_password,
             self.sendmail_command,
             self.postmark_token,
+            self.postmark_api,
         )?;
 
         // Assign IDs to limit configs.

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -4,7 +4,7 @@
   "license": "(MIT OR Apache-2.0)",
   "private": true,
   "scripts": {
-    "test": "./main.js",
+    "test": "node ./main.js",
     "test:chrome": "cross-env SELENIUM_BROWSER=chrome npm test",
     "test:firefox": "cross-env SELENIUM_BROWSER=firefox npm test"
   },

--- a/tests/e2e/src/broker.ts
+++ b/tests/e2e/src/broker.ts
@@ -67,6 +67,7 @@ export default ({ mailbox }: { mailbox: Mailbox }): Broker => {
       break;
     case "postmark":
       env.BROKER_POSTMARK_TOKEN = "POSTMARK_API_TEST";
+      env.BROKER_POSTMARK_API = "http://localhost:44920/postmark";
       break;
     default:
       throw Error(`Invalid TEST_MAILER: ${TEST_MAILER}`);

--- a/tests/e2e/src/http-mailer.ts
+++ b/tests/e2e/src/http-mailer.ts
@@ -1,0 +1,40 @@
+import express from "express";
+import bodyParser from "body-parser";
+
+export interface HttpMailerRequest {
+  headers: { [key: string]: string | string[] | undefined };
+  body: any;
+}
+
+export interface HttpMailer {
+  destroy(): void;
+  clearRequests(): void;
+  getRequests(): HttpMailerRequest[];
+}
+
+const jsonParser = bodyParser.json();
+
+export default (): HttpMailer => {
+  const app = express();
+
+  let requests: HttpMailerRequest[] = [];
+
+  app.post("/postmark", jsonParser, (req, res) => {
+    requests.push({ headers: req.headers, body: req.body });
+    return res.json({ ErrorCode: 0 });
+  });
+
+  const server = app.listen(44920, "localhost");
+
+  return {
+    destroy() {
+      server.close();
+    },
+    clearRequests() {
+      requests = [];
+    },
+    getRequests() {
+      return requests;
+    },
+  };
+};

--- a/tests/e2e/src/http-mailer.ts
+++ b/tests/e2e/src/http-mailer.ts
@@ -1,5 +1,6 @@
 import express from "express";
 import bodyParser from "body-parser";
+import { Mailbox } from "./mailbox";
 
 export interface HttpMailerRequest {
   headers: { [key: string]: string | string[] | undefined };
@@ -14,13 +15,14 @@ export interface HttpMailer {
 
 const jsonParser = bodyParser.json();
 
-export default (): HttpMailer => {
+export default ({ mailbox }: { mailbox: Mailbox }): HttpMailer => {
   const app = express();
 
   let requests: HttpMailerRequest[] = [];
 
   app.post("/postmark", jsonParser, (req, res) => {
     requests.push({ headers: req.headers, body: req.body });
+    mailbox.pushMail(req.body.TextBody);
     return res.json({ ErrorCode: 0 });
   });
 

--- a/tests/e2e/src/main.ts
+++ b/tests/e2e/src/main.ts
@@ -7,6 +7,7 @@ import firefox from "selenium-webdriver/firefox";
 import createMailbox, { Mailbox } from "./mailbox";
 import createBroker, { Broker } from "./broker";
 import createRelyingParty, { RelyingParty } from "./relying-party";
+import createHttpMailer, { HttpMailer } from "./http-mailer";
 import createTests from "./tests";
 
 import { HEADLESS } from "./env";
@@ -15,19 +16,24 @@ const main = async () => {
   let mailbox: Mailbox | undefined,
     broker: Broker | undefined,
     relyingParty: RelyingParty | undefined,
+    httpMailer: HttpMailer | undefined,
     driver: WebDriver | undefined;
   try {
     mailbox = createMailbox();
     broker = createBroker({ mailbox });
     relyingParty = createRelyingParty();
+    httpMailer = createHttpMailer();
     driver = await createDriver();
-    await createTests({ mailbox, broker, relyingParty, driver });
+    await createTests({ mailbox, broker, relyingParty, httpMailer, driver });
   } finally {
     if (driver) {
       await driver.quit().catch((err) => {
         console.error("Error while stopping Selenium:");
         console.error(err);
       });
+    }
+    if (httpMailer) {
+      httpMailer.destroy();
     }
     if (relyingParty) {
       relyingParty.destroy!();

--- a/tests/e2e/src/main.ts
+++ b/tests/e2e/src/main.ts
@@ -22,7 +22,7 @@ const main = async () => {
     mailbox = createMailbox();
     broker = createBroker({ mailbox });
     relyingParty = createRelyingParty();
-    httpMailer = createHttpMailer();
+    httpMailer = createHttpMailer({ mailbox });
     driver = await createDriver();
     await createTests({ mailbox, broker, relyingParty, httpMailer, driver });
   } finally {


### PR DESCRIPTION
This PR adds support for testing the HTTP requests sent to HTTP mailers as part of the JavaScript E2E tests.

Based on the suggestions from @stephank, I added a new config option `BROKER_POSTMARK_API`, which is undocumented as it's only intended to be used during tests. The value of this environment variable is used as the endpoint where the postmark mailer sends HTTP requests. If not specified, it defaults to Postmark's API.

I've also added a new test utility, `postmarkTest`, that only runs the test when `TEST_MAILER` is equal to `postmark`.

The approached used in this PR lay the foundation for adding new HTTP-based email APIs such as Mailgun.

(Also, as a small tweak, I've added the `node` executable to the npm test script since Windows doesn't support specifying interpreters with the hashbang syntax.)