### PR TITLE
Bump redis crate to v0.17.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,16 +22,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "ascii"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
-
-[[package]]
 name = "ascii_utils"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71938f30533e4d95a6d17aa530939da3842c2ab6f4f84b9dae68447e4129f74a"
+
+[[package]]
+name = "async-trait"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3a45e77e34375a7923b1e8febb049bb011f064714a8e17a1a616fef01da13d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "autocfg"
@@ -140,6 +145,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0dcbc35f504eb6fc275a6d20e4ebcda18cf50d40ba6fabff8c711fa16cb3b16"
 
 [[package]]
+name = "bytes"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad1f8e949d755f9d79112b5bb46938e0ef9d3804a0b16dfab13aafcaa5f0fa72"
+
+[[package]]
 name = "cc"
 version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -181,15 +192,16 @@ dependencies = [
 
 [[package]]
 name = "combine"
-version = "3.8.1"
+version = "4.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3da6baa321ec19e1cc41d31bf599f00c783d0517095cdaf0332e3fe8d20680"
+checksum = "01199925a18b00193570e3d70cfe57dcb647eb167c29851983e76fc39e2fee39"
 dependencies = [
- "ascii",
- "byteorder",
- "either",
+ "bytes 0.5.6",
+ "bytes 1.0.0",
+ "futures-util",
  "memchr",
- "unreachable",
+ "pin-project-lite 0.1.11",
+ "tokio",
 ]
 
 [[package]]
@@ -234,12 +246,6 @@ name = "dtoa"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
-
-[[package]]
-name = "either"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "email"
@@ -425,15 +431,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "847ce131b72ffb13b6109a221da9ad97a64cbe48feb1028356b836b47b8f1748"
 
 [[package]]
-name = "futures-executor"
+name = "futures-io"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4caa2b2b68b880003057c1dd49f1ed937e38f22fcf6c212188a121f08cf40a65"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
+checksum = "611834ce18aaa1bd13c4b374f5d653e1027cf99b6b502584ff8c9a64413b30bb"
 
 [[package]]
 name = "futures-macro"
@@ -469,9 +470,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d304cff4a7b99cfb7986f7d43fbe93d175e72e704a8860787cc95e9ffd85cbd2"
 dependencies = [
  "futures-core",
+ "futures-io",
  "futures-macro",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project 1.0.2",
  "pin-utils",
  "proc-macro-hack",
@@ -524,7 +527,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util 0.3.1",
+ "tokio-util",
  "tracing",
  "tracing-futures",
 ]
@@ -1115,6 +1118,7 @@ dependencies = [
  "accept-language",
  "base64 0.13.0",
  "bytes 0.6.0",
+ "combine",
  "docopt",
  "envy",
  "futures-util",
@@ -1354,21 +1358,21 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "0.15.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eeb1fe3fc011cde97315f370bc88e4db3c23b08709a04915921e02b1d363b20"
+checksum = "95357caf2640abc54651b93c98a8df4fe1ccbf44b8e601ccdf43d5c1451f29ac"
 dependencies = [
+ "async-trait",
  "bytes 0.5.6",
  "combine",
  "dtoa",
- "futures-executor",
  "futures-util",
  "itoa",
  "percent-encoding",
  "pin-project-lite 0.1.11",
  "sha1",
  "tokio",
- "tokio-util 0.2.0",
+ "tokio-util",
  "url",
 ]
 
@@ -1707,20 +1711,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "571da51182ec208780505a32528fc5512a8fe1443ab960b3f2f3ef093cd16930"
-dependencies = [
- "bytes 0.5.6",
- "futures-core",
- "futures-sink",
- "log 0.4.11",
- "pin-project-lite 0.1.11",
- "tokio",
-]
-
-[[package]]
-name = "tokio-util"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
@@ -1825,15 +1815,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
-name = "unreachable"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
-dependencies = [
- "void",
-]
-
-[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1887,12 +1868,6 @@ name = "version_check"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
-
-[[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,11 @@ serde_json = "1.0.57"
 thiserror = "1.0.22"
 toml = "0.5.6"
 
+[dependencies.combine]
+version = "4.5"
+default-features = false
+features = ["std"]
+
 [dependencies.lettre]
 optional = true
 version = "0.9.3"
@@ -62,9 +67,9 @@ features = ["std", "release_max_level_info"]
 
 [dependencies.redis]
 optional = true
-version = "0.15.1"
+version = "0.17.0"
 default-features = false
-features = ["tokio-rt-core"]
+features = ["tokio-rt-core", "script"]
 
 [dependencies.rusqlite]
 optional = true

--- a/src/utils/redis/pubsub.rs
+++ b/src/utils/redis/pubsub.rs
@@ -282,7 +282,12 @@ pub async fn connect(info: &ConnectionInfo) -> RedisResult<Subscriber> {
     let mut tx = WriteHalf(tx);
 
     if let Some(ref passwd) = info.passwd {
-        tx.write(&[b"AUTH", passwd.as_bytes()]).await?;
+        if let Some(ref username) = info.username {
+            tx.write(&[b"AUTH", username.as_bytes(), passwd.as_bytes()])
+                .await?;
+        } else {
+            tx.write(&[b"AUTH", passwd.as_bytes()]).await?;
+        }
         match rx.read().await {
             Ok(Value::Okay) => (),
             _ => {

--- a/src/utils/redis/pubsub.rs
+++ b/src/utils/redis/pubsub.rs
@@ -256,7 +256,10 @@ pub async fn connect(info: &ConnectionInfo) -> RedisResult<Subscriber> {
         }
 
         ConnectionAddr::TcpTls { .. } => {
-            return Err(RedisError::from((ErrorKind::InvalidClientConfig, "TLS connections not yet supported")))
+            return Err(RedisError::from((
+                ErrorKind::InvalidClientConfig,
+                "TLS connections not yet supported",
+            )))
         }
 
         #[cfg(unix)]


### PR DESCRIPTION
`redis` v0.17.0 [added support for Redis 6 auth](https://github.com/mitsuhiko/redis-rs/blob/master/CHANGELOG.md#0170---2020-07-29), which many hosted Redis providers are now offering. The main feature of Redis 6 that portier is currently incompatible with is username/password auth.

This PR bumps the `redis` crate's version to the oldest version with support for Redis 6 auth. Versions v0.18 and v0.19 contain larger changes (including an upgrade to tokio v1), so I wanted to keep this update as small as possible since my Rust skills aren't that great.

Upgrading required a few changes:

1. `parse_redis_value_async` now expects a decoder as the first argument. In `redis`, this decoder comes from the `combine` crate, so that's been added as a dependency.
2. v0.17.0 also supports TLS connections, so the Rust compiler is ensuring that portier is handling that option. However, since adding those options would be a bit more complicated, I've simply returned an error stating that TLS connections aren't supported yet.
3. `pubsub.rs` was updated to authenticate with username/password when both are provided.