### PR TITLE
Add release helper, disable cache on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,7 +111,7 @@ jobs:
 
     - name: E2E test Postmark
       run: cd tests/e2e/ && TEST_MAILER=postmark ./main.js
-    
+
     - name: E2E test Mailgun
       run: cd tests/e2e/ && TEST_MAILER=mailgun ./main.js
 
@@ -125,6 +125,12 @@ jobs:
   macos-build:
     runs-on: macos-latest
     steps:
+
+    # Workaround for: https://github.com/actions/cache/issues/403
+    - name: Install GNU tar
+      run: |
+        brew install gnu-tar
+        echo PATH="/usr/local/opt/gnu-tar/libexec/gnubin:$PATH" >> $GITHUB_ENV
 
     - name: Checkout
       uses: actions/checkout@v2
@@ -143,7 +149,7 @@ jobs:
           ~/.cargo/registry
           ~/.cargo/git
           target
-        key: v1-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        key: v2-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
     - name: Build
       run: cargo build --locked

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
 
+    # Workaround for: https://github.com/actions/cache/issues/403
+    - name: Install GNU tar
+      if: runner.os == 'macOS'
+      run: |
+        brew install gnu-tar
+        echo PATH="/usr/local/opt/gnu-tar/libexec/gnubin:$PATH" >> $GITHUB_ENV
+
     - name: Checkout
       uses: actions/checkout@v2
 
@@ -35,7 +42,7 @@ jobs:
           ~/.cargo/registry
           ~/.cargo/git
           target
-        key: v1-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        key: v2-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
     - name: Build
       run: cargo build --release --locked

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# Script to automate creating a (draft) release.
+#
+# After running this script, manually add release notes and publish the
+# release. CI will then make release builds and attach them automatically.
+
+set -e
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+# Show usage on invalid args.
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 <version>"
+  exit 64
+fi
+
+# Check if git tree is clean.
+if [ ! -z "$(git status --porcelain)" ]; then
+  echo "Working directory is not clean."
+  exit 1
+fi
+
+# Summarize actions.
+echo "About to create a release $1, with recent commits:"
+echo
+git log --oneline --max-count 10 | cat
+echo
+read -p "Continue? (y/n)" CONT
+if [ "$CONT" != "y" ]; then
+  echo "Cancelled."
+  exit 1
+fi
+
+# Echo commands from here.
+set -x
+
+# Update the version in Cargo.toml.
+#
+# Assumes it's somewhere in the first 5 lines, because we want to avoid
+# replacing dependency versions.
+sed -i '' -e "1,5 s/^version = \".*\"/version = \"$1\"/" Cargo.toml
+
+# Run Cargo to have it update Cargo.lock.
+cargo check
+
+# Create a commit and push.
+git commit -m "Version $1" Cargo.toml Cargo.lock
+git push
+
+# Create a draft release on GitHub.
+gh release create "v$1" --draft --title "v$1"


### PR DESCRIPTION
The release helper is from the discussion in #226. I tested the script up to (and except) the `git push` and `gh release create` lines.