### PR TITLE
resolve "error: panic message is not a string literal" errors

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -111,7 +111,7 @@ async fn start_server(builder: ConfigBuilder) {
         builder
             .done()
             .await
-            .unwrap_or_else(|err| panic!(format!("failed to build configuration: {}", err))),
+            .unwrap_or_else(|err| panic!("failed to build configuration: {}", err)),
     );
 
     // TODO: Add unix socket support.
@@ -183,7 +183,7 @@ async fn import_key(builder: ConfigBuilder, file: &Path) {
     let store = builder
         .into_store()
         .await
-        .unwrap_or_else(|err| panic!(format!("failed to build configuration: {}", err)));
+        .unwrap_or_else(|err| panic!("failed to build configuration: {}", err));
 
     let signing_alg = match key {
         ParsedKeyPair::Ed25519(_) => SigningAlgorithm::EdDsa,

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -92,10 +92,10 @@ mod tests {
             "http://example.com:8080/path?foo=bar",
         ] {
             if let Err(err) = parse_redirect_uri(uri, "input") {
-                panic!(format!(
+                panic!(
                     "unexpectedly rejected uri: {}. Reported: {}",
                     uri, err
-                ))
+                )
             }
         }
     }
@@ -137,7 +137,7 @@ mod tests {
             "http://»",
         ] {
             if parse_redirect_uri(uri, "input").is_ok() {
-                panic!(format!("did not reject uri: {}", uri))
+                panic!("did not reject uri: {}", uri)
             }
         }
     }
@@ -167,7 +167,7 @@ mod tests {
         ] {
             let uri = uri.parse().expect("could not parse a test uri");
             if parse_oidc_href(&uri).is_none() {
-                panic!(format!("unexpectedly rejected uri: {}", uri))
+                panic!("unexpectedly rejected uri: {}", uri)
             }
         }
     }
@@ -190,7 +190,7 @@ mod tests {
             println!("{}", uri);
             let uri = uri.parse().expect("could not parse a test uri");
             if parse_oidc_href(&uri).is_some() {
-                panic!(format!("did not reject uri: {}", uri))
+                panic!("did not reject uri: {}", uri)
             }
         }
     }


### PR DESCRIPTION
portier fails to build with Rust 1.51, bombing out with:
```
error: panic message is not a string literal
   --> src/main.rs:114:42
    |
114 |             .unwrap_or_else(|err| panic!(format!("failed to build configuration: {}", err))),
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
note: the lint level is defined here
   --> src/main.rs:1:9
    |
1   | #![deny(warnings, clippy::pedantic)]
    |         ^^^^^^^^
    = note: `#[deny(non_fmt_panic)]` implied by `#[deny(warnings)]`
    = note: this is no longer accepted in Rust 2021
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

error: panic message is not a string literal
   --> src/main.rs:186:38
    |
186 |         .unwrap_or_else(|err| panic!(format!("failed to build configuration: {}", err)));
    |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this is no longer accepted in Rust 2021
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

error: aborting due to 2 previous errors

error: could not compile `portier_broker`
```

I have no idea if the fix is 'correct', Rust really is not my thing, but it makes the errors go away and a binary is emitted...