### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This should configure dependabot to create PRs automatically for version updates. Docs for the YAML are here: https://docs.github.com/en/code-security/supply-chain-security/configuration-options-for-dependency-updates

This'll probably be a bit of churn, but I think that's fine. Right now, updates are ad hoc, but some stuff is probably security sensitive.

If I understand docs correctly, this'll only update `Cargo.lock` for Rust, but we'll see. I also wonder if we could do `allow: []` in the future to have it do just security updates.