### PR TITLE
docker: use new debian, add data_url arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,32 +5,35 @@
 #   docker run -v /srv/portier-broker:/data:ro portier/broker /data/config.toml
 #
 
-# Create a release build.
-FROM rust:1-buster as build
-WORKDIR /src
+# Stage 1: Build the broker in release mode.
+FROM rust:1-bullseye AS build
+WORKDIR /build
 COPY . .
 RUN cargo build --release
 
-# Prepare a 'package' directory with the exact files we want.
-RUN set -x \
-  && mkdir package \
-  && cp -R \
-    lang \
-    res \
-    tmpl \
-    target/release/portier-broker \
-    package/ \
-  && rm lang/*.po
+# Stage 2: Prepare data files.
+FROM alpine AS data
+WORKDIR /data
+COPY lang ./lang
+COPY res ./res
+COPY tmpl ./tmpl
+# Allow overriding via a build arg. We throw away our earlier work, but that's
+# fine, because only the last stage matters for the output image.
+ARG data_url
+RUN if [ -n "$data_url" ]; then \
+  rm -fr lang res tmpl; \
+  wget -O - "$data_url" | tar -xz; \
+fi
+# Don't keep translation source files.
+RUN rm -f ./lang/*.po
 
-# Prepare a final image from a plain Debian base.
-FROM debian:buster
-
+# Stage 3: Prepare a final image from a plain Debian base.
+FROM debian:bullseye AS out
 # Add a user and group first to make sure their IDs get assigned consistently,
 # regardless of whatever dependencies get added.
 RUN set -x \
   && groupadd -r -g 999 portier-broker \
   && useradd -r -g portier-broker -u 999 portier-broker
-
 # Install run-time dependencies.
 RUN set -x \
   && apt-get update \
@@ -38,12 +41,11 @@ RUN set -x \
     openssl \
     ca-certificates \
   && rm -rf /var/lib/apt/lists/*
-
-# Copy in the 'package' directory from the build image.
-COPY --from=build /src/package /opt/portier-broker
-WORKDIR /opt/portier-broker
-
+# Copy in the build and data files.
+COPY --from=build /build/target/release/portier-broker /opt/portier-broker/
+COPY --from=data /data /opt/portier-broker
 # Set image settings.
+WORKDIR /opt/portier-broker
 ENTRYPOINT ["/opt/portier-broker/portier-broker"]
 USER portier-broker
 ENV BROKER_LISTEN_IP=::


### PR DESCRIPTION
Based on #240. Does this work for you @jimdigriz? I tried with and without `data_url`, and think it works as expected. Not sure if you had a specific need for the `slim` image variants?

Example output of `docker image history`:

```
IMAGE          CREATED             CREATED BY                                      SIZE      COMMENT
439b77868c37   About an hour ago   EXPOSE map[3333/tcp:{}]                         0B        buildkit.dockerfile.v0
<missing>      About an hour ago   ENV BROKER_LISTEN_IP=::                         0B        buildkit.dockerfile.v0
<missing>      About an hour ago   USER portier-broker                             0B        buildkit.dockerfile.v0
<missing>      About an hour ago   ENTRYPOINT ["/opt/portier-broker/portier-bro…   0B        buildkit.dockerfile.v0
<missing>      About an hour ago   WORKDIR /opt/portier-broker                     0B        buildkit.dockerfile.v0
<missing>      About an hour ago   COPY /data /opt/portier-broker # buildkit       14.5kB    buildkit.dockerfile.v0
<missing>      About an hour ago   COPY /build/target/release/portier-broker /o…   20.5MB    buildkit.dockerfile.v0
<missing>      About an hour ago   RUN /bin/sh -c set -x   && apt-get update   …   3.68MB    buildkit.dockerfile.v0
<missing>      About an hour ago   RUN /bin/sh -c set -x   && groupadd -r -g 99…   329kB     buildkit.dockerfile.v0
<missing>      8 days ago          /bin/sh -c #(nop)  CMD ["bash"]                 0B
<missing>      8 days ago          /bin/sh -c #(nop) ADD file:22ed184e421fcac77…   124MB
```