### PR TITLE
Build releases for more platforms, multiarch Docker images

### DIFF
--- a/.github/actions/prep-linux-cross/action.yml
+++ b/.github/actions/prep-linux-cross/action.yml
@@ -1,0 +1,12 @@
+name: prep-linux-cross
+description: Preparation for Linux cross compiling
+inputs:
+  targets:
+    description: Target triples to prepare for.
+    required: true
+  packages:
+    description: Debian packages to install for all targets.
+    required: false
+runs:
+  using: node12
+  main: main.js

--- a/.github/actions/prep-linux-cross/main.js
+++ b/.github/actions/prep-linux-cross/main.js
@@ -1,0 +1,121 @@
+const fs = require("fs");
+const childProcess = require("child_process");
+
+if (process.arch !== "x64" || process.platform !== "linux") {
+  throw Error(`Unsupported host: ${process.arch} ${process.platform}`);
+}
+const NATIVE_TRIPLE = "x86_64-unknown-linux-gnu";
+
+const TARGET_TRIPLE_TO_DEBIAN_ARCH = {
+  "aarch64-unknown-linux-gnu": "arm64",
+  "arm-unknown-linux-gnueabihf": "armhf",
+  "armv7-unknown-linux-gnueabihf": "armhf",
+  "i686-unknown-linux-gnu": "i386",
+  "mips64el-unknown-linux-gnuabi64": "mips64el",
+  "powerpc64le-unknown-linux-gnu": "ppc64el",
+  "s390x-unknown-linux-gnu": "s390x",
+  "x86_64-unknown-linux-gnu": "amd64",
+};
+
+function hasProp(obj, name) {
+  return Object.prototype.hasOwnProperty.call(obj, name);
+}
+
+function getInputSet(name) {
+  return new Set(
+    (process.env[`INPUT_${name.toUpperCase()}`] || "")
+      .split(/\s+/g)
+      .filter((x) => x)
+  );
+}
+
+function exec(file, args) {
+  childProcess.execFileSync(file, args, {
+    stdio: ["ignore", "inherit", "inherit"],
+  });
+}
+
+function main() {
+  const targets = getInputSet("targets");
+  const packages = getInputSet("packages");
+
+  // Provides crt1.o
+  packages.add("libc6-dev");
+
+  const dpkgArchs = new Set();
+  const aptPackages = new Set([
+    "gcc",
+    "pkg-config",
+    // Required for the Debian pkg-config cross wrapper.
+    "dpkg-dev",
+  ]);
+  let bashCases = "";
+
+  for (const target of targets) {
+    if (!hasProp(TARGET_TRIPLE_TO_DEBIAN_ARCH, target)) {
+      throw Error(`Unsupported target: ${target}`);
+    }
+
+    const debianArch = TARGET_TRIPLE_TO_DEBIAN_ARCH[target];
+
+    // Derive the GCC target name.
+    const gccTarget = target
+      // Assumption: all our supported targets have vendor 'unknown'.
+      .replace("-unknown", "")
+      // ARM is not versioned in the GCC triple.
+      .replace(/armv\d+/g, "arm")
+      // Dashes only.
+      .replace(/_/g, "-");
+
+    if (target === NATIVE_TRIPLE) {
+      bashCases += `
+        ${target})
+          echo -n > ~/.cargo/config
+          export -n PKG_CONFIG
+          ;;
+      `;
+    } else {
+      dpkgArchs.add(debianArch);
+      aptPackages.add(`gcc-${gccTarget}`);
+      bashCases += `
+        ${target})
+          echo "[target.'${target}']" > ~/.cargo/config
+          echo "linker = '${gccTarget}-gcc'" >> ~/.cargo/config
+          export PKG_CONFIG="${gccTarget}-pkg-config"
+          ;;
+      `;
+    }
+
+    for (const pkg of packages) {
+      aptPackages.add(`${pkg}:${debianArch}`);
+    }
+  }
+
+  for (const arch of dpkgArchs) {
+    exec("dpkg", ["--add-architecture", arch]);
+  }
+
+  exec("apt-get", ["update", "-y"]);
+  exec("apt-get", ["install", "-y", "--no-install-recommends", ...aptPackages]);
+
+  const bashScript = `
+    prep_cross() {
+      mkdir -p ~/.cargo
+      case $1 in
+        ${bashCases}
+        *)
+          echo >&2 "Invalid target: $1"
+          exit 1
+          ;;
+      esac
+    }
+  `;
+  fs.writeFileSync("/tmp/prep_cross.sh", bashScript);
+}
+
+try {
+  main();
+} catch (err) {
+  process.exitCode = 1;
+  console.log(`::error::${err.message}`);
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
           ~/.cargo/registry
           ~/.cargo/git
           target
-        key: v1-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
     - name: Check
       run: cargo check --locked
@@ -60,7 +60,7 @@ jobs:
           ~/.cargo/registry
           ~/.cargo/git
           target
-        key: v1-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
     - name: Build
       run: cargo build --locked
@@ -153,7 +153,7 @@ jobs:
           ~/.cargo/registry
           ~/.cargo/git
           target
-        key: v2-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
     - name: Build
       run: cargo build --locked

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,6 +189,7 @@ jobs:
         basename="Portier-Broker-${tag_name}-Darwin"
         mkdir $basename
         lipo -create -output $basename/portier-broker ./target/*/release/portier-broker
+        codesign --force -s - $basename/portier-broker
         cp -r $package_resources $basename/
         tar -czf "release-packages/$basename.tgz" $basename
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,29 +4,72 @@ on:
   release:
     types: [created]
 
+defaults:
+  run:
+    shell: bash
+
 env:
+  tag_name: ${{ github.event.release.tag_name }}
   package_resources: >-
     README.md LICENSE-APACHE LICENSE-MIT
     docs lang res tmpl
     config.toml.dist
 
 jobs:
-  release:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
-    steps:
+  release-linux:
+    runs-on: ubuntu-latest
+    container: "debian:bullseye"
+    env:
 
-    # Workaround for: https://github.com/actions/cache/issues/403
-    - name: Install GNU tar
-      if: runner.os == 'macOS'
-      run: |
-        brew install gnu-tar
-        echo PATH="/usr/local/opt/gnu-tar/libexec/gnubin:$PATH" >> $GITHUB_ENV
+      # NOTE: Packages are named after the first component of the target
+      # triple, so these must be unique.
+      # NOTE: On Linux, we are limited mostly by arch support in Ring.
+      build_targets: |
+        aarch64-unknown-linux-gnu
+        arm-unknown-linux-gnueabihf
+        armv7-unknown-linux-gnueabihf
+        i686-unknown-linux-gnu
+        x86_64-unknown-linux-gnu
+
+    steps:
 
     - name: Checkout
       uses: actions/checkout@v2
+
+    # Docker Debian images clear APT cache after every operation.
+    # This disables those settings, so GitHub can use the cache.
+    - name: Prepare APT cache
+      run: |
+        rm /etc/apt/apt.conf.d/docker-clean
+
+    - name: APT cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          /var/cache/apt/
+          /var/lib/apt/lists/
+        key: debian-bullseye-apt
+
+    - name: Prepare cross
+      uses: ./.github/actions/prep-linux-cross
+      with:
+        targets: ${{ env.build_targets }}
+        packages: libssl-dev
+
+    # The previous step already did `apt-get update`, so install only.
+    # - curl & ca-certificates are used for installing Rust and GitHub CLI.
+    # - git is a dependency of GitHub CLI.
+    - name: Add packages
+      run: |
+        apt-get install -y --no-install-recommends \
+          curl ca-certificates \
+          git
+
+    - name: Install GitHub CLI
+      run: |
+        curl -Lo gh.deb https://github.com/cli/cli/releases/download/v1.11.0/gh_1.11.0_linux_amd64.deb
+        dpkg -i gh.deb
+        rm gh.deb
 
     - name: Install Rust
       uses: actions-rs/toolchain@v1
@@ -35,6 +78,10 @@ jobs:
         profile: minimal
         default: true
 
+    - name: Add targets
+      run: |
+        rustup target add $build_targets
+
     - name: Cache
       uses: actions/cache@v2
       with:
@@ -42,39 +89,117 @@ jobs:
           ~/.cargo/registry
           ~/.cargo/git
           target
-        key: v2-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
     - name: Build
-      run: cargo build --release --locked
+      run: |
+        source /tmp/prep_cross.sh  # Written by prep-linux-cross
+        for target in $build_targets; do
+          echo "-- Building for $target"
+          prep_cross $target
+          cargo build --release --locked --target $target
+        done
 
     - name: Package
-      id: package
       run: |
-        broker_executable="./target/release/portier-broker"
-        tag_name="${{ github.event.release.tag_name }}"
-        basename="Portier-Broker-$tag_name-$(uname -s)-$(uname -m)"
-        filename="$basename.tgz"
+        mkdir release-packages
+        for target in $build_targets; do
+          echo "-- Packaging for $target"
+          broker_executable="./target/$target/release/portier-broker"
+          basename="Portier-Broker-$tag_name-Linux-${target/-*/}"
 
-        mkdir $basename
-        mv $broker_executable $basename/
-        mv $package_resources $basename/
-        tar -czf $filename $basename
-
-        echo "##[set-output name=filename]$filename"
-        echo "##[set-output name=content_type]application/gzip"
+          mkdir $basename
+          cp $broker_executable $basename/
+          cp -r $package_resources $basename/
+          tar -czf "release-packages/$basename.tgz" $basename
+        done
 
     - name: Upload
-      uses: actions/upload-release-asset@v1.0.2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        gh release upload "$tag_name" release-packages/*
+
+  release-macos:
+    runs-on: macos-latest
+    env:
+
+      # NOTE: Packages are named after the first component of the triple, so
+      # these must be unique.
+      build_targets: |
+        aarch64-apple-darwin
+        x86_64-apple-darwin
+
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    # Workaround for: https://github.com/actions/virtual-environments/issues/2557#issuecomment-769611326
+    - name: Configure Xcode
+      run: |
+        sudo xcode-select -s /Applications/Xcode_12.4.app
+        sudo rm -Rf /Library/Developer/CommandLineTools/SDKs/*
+
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
       with:
-        upload_url: ${{ github.event.release.upload_url }}
-        asset_path: ./${{ steps.package.outputs.filename }}
-        asset_name: ${{ steps.package.outputs.filename }}
-        asset_content_type: ${{ steps.package.outputs.content_type }}
+        toolchain: stable
+        profile: minimal
+        default: true
+
+    - name: Add targets
+      run: |
+        rustup target add $build_targets
+
+    - name: Cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+    - name: Build
+      run: |
+        for target in $build_targets; do
+          echo "-- Building for $target"
+          cargo build --release --locked --target $target
+        done
+
+    - name: Package
+      run: |
+        rm -fr docs/systemd  # Linux-specific
+
+        mkdir release-packages
+        for target in $build_targets; do
+          echo "-- Packaging for $target"
+          broker_executable="./target/$target/release/portier-broker"
+          basename="Portier-Broker-$tag_name-Darwin-${target/-*/}"
+
+          mkdir $basename
+          cp $broker_executable $basename/
+          cp -r $package_resources $basename/
+          tar -czf "release-packages/$basename.tgz" $basename
+        done
+
+    - name: Upload
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        gh release upload "$tag_name" release-packages/*
 
   release-windows:
     runs-on: windows-latest
+    env:
+
+      # NOTE: Packages are named after the first component of the triple, so
+      # these must be unique.
+      build_targets: |
+        i686-pc-windows-msvc
+        x86_64-pc-windows-msvc
+
     steps:
 
     - name: Checkout
@@ -87,6 +212,10 @@ jobs:
         profile: minimal
         default: true
 
+    - name: Add targets
+      run: |
+        rustup target add $build_targets
+
     - name: Cache
       uses: actions/cache@v2
       with:
@@ -94,33 +223,33 @@ jobs:
           ~/.cargo/registry
           ~/.cargo/git
           target
-        key: v1-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
     - name: Build
-      run: cargo build --release --locked
+      run: |
+        for target in $build_targets; do
+          echo "-- Building for $target"
+          cargo build --release --locked --target $target
+        done
 
     - name: Package
-      id: package
       run: |
-        $broker_executable="./target/release/portier-broker.exe"
-        $tag_name="${{ github.event.release.tag_name }}"
-        $basename="Portier-Broker-$tag_name-Windows-x86_64"
-        $filename="$basename.zip"
+        rm -fr docs/systemd  # Linux-specific
 
-        mkdir $basename
-        mv $broker_executable $basename/
-        mv $env:package_resources.split() $basename/
-        7z a -tzip $filename $basename
+        mkdir release-packages
+        for target in $build_targets; do
+          echo "-- Packaging for $target"
+          broker_executable="./target/$target/release/portier-broker.exe"
+          basename="Portier-Broker-$tag_name-Windows-${target/-*/}"
 
-        echo "##[set-output name=filename]$filename"
-        echo "##[set-output name=content_type]application/zip"
+          mkdir $basename
+          cp $broker_executable $basename/
+          cp -r $package_resources $basename/
+          7z a -tzip "release-packages/$basename.zip" $basename
+        done
 
     - name: Upload
-      uses: actions/upload-release-asset@v1.0.2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ github.event.release.upload_url }}
-        asset_path: ./${{ steps.package.outputs.filename }}
-        asset_name: ${{ steps.package.outputs.filename }}
-        asset_content_type: ${{ steps.package.outputs.content_type }}
+      run: |
+        gh release upload "$tag_name" release-packages/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,22 +185,12 @@ jobs:
         rm -fr docs/systemd  # Linux-specific
 
         mkdir release-packages
-        for target in $build_targets; do
-          broker_executable="./target/$target/release/portier-broker"
-          if [ ! -f "$broker_executable" ]; then
-            continue
-          fi
 
-          echo "::group::Packaging for $target"
-          basename="Portier-Broker-${tag_name}-Darwin-${target/-*/}"
-
-          mkdir $basename
-          cp $broker_executable $basename/
-          cp -r $package_resources $basename/
-          tar -czf "release-packages/$basename.tgz" $basename
-
-          echo "::endgroup::"
-        done
+        basename="Portier-Broker-${tag_name}-Darwin"
+        mkdir $basename
+        lipo -create -output $basename/portier-broker ./target/*/release/portier-broker
+        cp -r $package_resources $basename/
+        tar -czf "release-packages/$basename.tgz" $basename
 
     - name: Upload
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,9 +33,6 @@ jobs:
 
     steps:
 
-    - name: Checkout
-      uses: actions/checkout@v2
-
     # Docker Debian images clear APT cache after every operation.
     # This disables those settings, so GitHub can use the cache.
     - name: Prepare APT cache
@@ -50,20 +47,23 @@ jobs:
           /var/lib/apt/lists/
         key: debian-bullseye-apt
 
+    # - curl & ca-certificates are used for installing Rust and GitHub CLI.
+    # - git is a dependency of actions/checkout and GitHub CLI.
+    - name: Add packages
+      run: |
+        apt-get update -y
+        apt-get install -y --no-install-recommends \
+          curl ca-certificates \
+          git
+
+    - name: Checkout
+      uses: actions/checkout@v2
+
     - name: Prepare cross
       uses: ./.github/actions/prep-linux-cross
       with:
         targets: ${{ env.build_targets }}
         packages: libssl-dev
-
-    # The previous step already did `apt-get update`, so install only.
-    # - curl & ca-certificates are used for installing Rust and GitHub CLI.
-    # - git is a dependency of GitHub CLI.
-    - name: Add packages
-      run: |
-        apt-get install -y --no-install-recommends \
-          curl ca-certificates \
-          git
 
     - name: Install GitHub CLI
       run: |
@@ -95,23 +95,32 @@ jobs:
       run: |
         source /tmp/prep_cross.sh  # Written by prep-linux-cross
         for target in $build_targets; do
-          echo "-- Building for $target"
+          echo "::group::Building for $target"
           prep_cross $target
-          cargo build --release --locked --target $target
+          if ! cargo build --release --locked --target $target; then
+            echo "::warning::Build for $target failed"
+          fi
+          echo "::endgroup::"
         done
 
     - name: Package
       run: |
         mkdir release-packages
         for target in $build_targets; do
-          echo "-- Packaging for $target"
           broker_executable="./target/$target/release/portier-broker"
-          basename="Portier-Broker-$tag_name-Linux-${target/-*/}"
+          if [ ! -f "$broker_executable" ]; then
+            continue
+          fi
+
+          echo "::group::Packaging for $target"
+          basename="Portier-Broker-${tag_name}-Linux-${target/-*/}"
 
           mkdir $basename
           cp $broker_executable $basename/
           cp -r $package_resources $basename/
           tar -czf "release-packages/$basename.tgz" $basename
+
+          echo "::endgroup::"
         done
 
     - name: Upload
@@ -164,8 +173,11 @@ jobs:
     - name: Build
       run: |
         for target in $build_targets; do
-          echo "-- Building for $target"
-          cargo build --release --locked --target $target
+          echo "::group::Building for $target"
+          if ! cargo build --release --locked --target $target; then
+            echo "::warning::Build for $target failed"
+          fi
+          echo "::endgroup::"
         done
 
     - name: Package
@@ -174,14 +186,20 @@ jobs:
 
         mkdir release-packages
         for target in $build_targets; do
-          echo "-- Packaging for $target"
           broker_executable="./target/$target/release/portier-broker"
-          basename="Portier-Broker-$tag_name-Darwin-${target/-*/}"
+          if [ ! -f "$broker_executable" ]; then
+            continue
+          fi
+
+          echo "::group::Packaging for $target"
+          basename="Portier-Broker-${tag_name}-Darwin-${target/-*/}"
 
           mkdir $basename
           cp $broker_executable $basename/
           cp -r $package_resources $basename/
           tar -czf "release-packages/$basename.tgz" $basename
+
+          echo "::endgroup::"
         done
 
     - name: Upload
@@ -228,8 +246,11 @@ jobs:
     - name: Build
       run: |
         for target in $build_targets; do
-          echo "-- Building for $target"
-          cargo build --release --locked --target $target
+          echo "::group::Building for $target"
+          if ! cargo build --release --locked --target $target; then
+            echo "::warning::Build for $target failed"
+          fi
+          echo "::endgroup::"
         done
 
     - name: Package
@@ -238,14 +259,20 @@ jobs:
 
         mkdir release-packages
         for target in $build_targets; do
-          echo "-- Packaging for $target"
           broker_executable="./target/$target/release/portier-broker.exe"
-          basename="Portier-Broker-$tag_name-Windows-${target/-*/}"
+          if [ ! -f "$broker_executable" ]; then
+            continue
+          fi
+
+          echo "::group::Packaging for $target"
+          basename="Portier-Broker-${tag_name}-Windows-${target/-*/}"
 
           mkdir $basename
           cp $broker_executable $basename/
           cp -r $package_resources $basename/
           7z a -tzip "release-packages/$basename.zip" $basename
+
+          echo "::endgroup::"
         done
 
     - name: Upload
@@ -253,3 +280,94 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         gh release upload "$tag_name" release-packages/*
+
+  release-linux-docker:
+    needs: release-linux
+    runs-on: ubuntu-latest
+    services:
+      # Scratch registry for building multiarch images.
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+    env:
+      scratch_repo: "localhost:5000/scratch"
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+      with:
+        platforms: arm,arm64
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+      with:
+        # Need network=host for the builder to contact our scratch registry.
+        driver: docker-container
+        driver-opts: network=host
+
+    - name: Build
+      run: |
+        # Map Docker arch to package name
+        declare -A build_targets
+        build_targets['386']='i686'
+        build_targets['amd64']='x86_64'
+        build_targets['arm/v6']='arm'
+        build_targets['arm/v7']='armv7'
+        build_targets['arm64/v8']='aarch64'
+
+        declare -a scratch_tags
+        for docker_arch in "${!build_targets[@]}"; do
+          pkg_arch="${build_targets[$docker_arch]}"
+
+          # This download may fail if the release build failed for this
+          # platform. Continue without the platform, in that case.
+          echo "::group::Downloading package for $pkg_arch"
+          basename="Portier-Broker-${tag_name}-Linux-${pkg_arch}"
+          if ! wget "https://github.com/portier/portier-broker/releases/download/${tag_name}/${basename}.tgz"; then
+            echo "::endgroup::"
+            continue
+          fi
+          tar -xzf $basename.tgz
+
+          echo "::endgroup::"
+          echo "::group::Building image for $docker_arch"
+
+          # Reuse the Dockerfile base system, but copy in the release instead
+          # of rebuilding. This ensures we use the same binaries everywhere.
+          cp Dockerfile Dockerfile-release
+          echo "FROM base AS release" >> Dockerfile-release
+          echo "COPY ./$basename /opt/portier-broker" >> Dockerfile-release
+
+          scratch_tag="$scratch_repo:$pkg_arch"
+          docker buildx build \
+            --platform linux/$docker_arch \
+            --push --tag "$scratch_tag" \
+            -f Dockerfile-release .
+
+          scratch_tags+=( "$scratch_tag" )
+          echo "::endgroup::"
+        done
+
+        # Create a combined 'latest' tag with the multiarch image list.
+        docker buildx imagetools create -t "$scratch_repo" "${scratch_tags[@]}"
+
+    - name: Upload
+      env:
+        SKOPEO_AUTH: ${{ secrets.SKOPEO_AUTH }}
+      run: |
+        mkdir -p "${HOME}/.config/containers"
+        echo "${SKOPEO_AUTH}" > "${HOME}/.config/containers/auth.json"
+
+        skopeo --insecure-policy copy --all --src-tls-verify=false \
+          "docker://$scratch_repo" \
+          "docker://portier/broker:$tag_name"
+
+        if ! grep -q "test" <<< "$tag_name"; then
+          skopeo copy --all \
+            "docker://portier/broker:$tag_name" \
+            "docker://portier/broker:latest"
+        fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,10 +24,10 @@ jobs:
       # NOTE: Packages are named after the first component of the target
       # triple, so these must be unique.
       # NOTE: On Linux, we are limited mostly by arch support in Ring.
+      # TODO: Add 32-bit ARM. Not sure whether we need hardfloat builds or not,
+      # and how to communicate this in our releases. Also need Docker images.
       build_targets: |
         aarch64-unknown-linux-gnu
-        arm-unknown-linux-gnueabihf
-        armv7-unknown-linux-gnueabihf
         i686-unknown-linux-gnu
         x86_64-unknown-linux-gnu
 
@@ -291,7 +291,7 @@ jobs:
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v1
       with:
-        platforms: arm,arm64
+        platforms: arm64
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
@@ -306,8 +306,6 @@ jobs:
         declare -A build_targets
         build_targets['386']='i686'
         build_targets['amd64']='x86_64'
-        build_targets['arm/v6']='arm'
-        build_targets['arm/v7']='armv7'
         build_targets['arm64/v8']='aarch64'
 
         declare -a scratch_tags

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 FROM rust:1-bullseye AS build
 WORKDIR /build
 COPY . .
-RUN cargo build --release
+RUN cargo build --release --locked
 
 # Stage 2: Prepare data files.
 FROM alpine AS data


### PR DESCRIPTION
I got a mail saying Docker autobuilds are going away, so we need to build and push from somewhere else, naturally GitHub Actions. I took the opportunity to work on improving the release scripts. This now builds for a larger set of platforms. The full set is now:

- Linux: ARMv6, ARMv7, ARM64 (v8), Intel 32-bit & 64-bit
- Windows: Intel 32-bit & 64-bit
- macOS: Apple Silicon, Intel 64-bit

See a test release here: https://github.com/portier/portier-broker/releases/tag/v0.4.0-test

This also pushes the Linux builds as a multiarch Docker image to Docker Hub. See the test release: https://hub.docker.com/repository/registry-1.docker.io/portier/broker/tags?name=v0.4.0-test

Here's the CI run of the test release: https://github.com/portier/portier-broker/actions/runs/931453513