### PR TITLE
Fix some clippy warnings

### DIFF
--- a/src/agents/key_manager/rotating.rs
+++ b/src/agents/key_manager/rotating.rs
@@ -164,7 +164,7 @@ impl RotatingKeys {
         RotatingKeys {
             store,
             keys_ttl,
-            signing_algs: signing_algs.iter().cloned().collect(),
+            signing_algs: signing_algs.iter().copied().collect(),
             generate_rsa_command,
             rng,
             ed25519_keys: None,

--- a/src/error.rs
+++ b/src/error.rs
@@ -28,30 +28,30 @@ impl BrokerError {
     /// Log this error at the appropriate log level.
     /// If `rng` is set, internal errors return a reference number for the error.
     pub async fn log(&self, rng: Option<&SecureRandom>) -> Option<String> {
-        match *self {
+        match self {
             // User errors only at debug level.
-            ref err @ BrokerError::Input(_)
-            | ref err @ BrokerError::ProviderInput(_)
-            | ref err @ BrokerError::RateLimited
-            | ref err @ BrokerError::SessionExpired
-            | ref err @ BrokerError::ProviderCancelled => {
-                debug!("{}", err);
+            BrokerError::Input(_)
+            | BrokerError::ProviderInput(_)
+            | BrokerError::RateLimited
+            | BrokerError::SessionExpired
+            | BrokerError::ProviderCancelled => {
+                debug!("{}", self);
                 None
             }
             // Provider errors can be noteworthy, especially when
             // the issue is network related.
-            ref err @ BrokerError::Provider(_) => {
-                info!("{}", err);
+            BrokerError::Provider(_) => {
+                info!("{}", self);
                 None
             }
             // Internal errors should ring alarm bells.
-            ref err @ BrokerError::Internal(_) => {
+            BrokerError::Internal(_) => {
                 if let Some(rng) = rng {
                     let reference = random_zbase32(6, rng).await;
-                    error!("[REF:{}] {}", reference, err);
+                    error!("[REF:{}] {}", reference, self);
                     Some(reference)
                 } else {
-                    error!("{}", err);
+                    error!("{}", self);
                     None
                 }
             }


### PR DESCRIPTION
There are some more left, but I believe fixing those would break on Rust 1.46, which is our current minimum version.