### PR TITLE
Add Prometheus-compatible metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1075,6 +1075,7 @@ dependencies = [
  "mustache",
  "native-tls",
  "percent-encoding",
+ "prometheus",
  "redis",
  "ring",
  "rusqlite",
@@ -1113,6 +1114,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a152013215dca273577e18d2bf00fa862b89b24169fb78c4c95aeb07992c9cec"
 dependencies = [
  "unicode-xid",
+]
+
+[[package]]
+name = "prometheus"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5986aa8d62380092d2f50f8b1cdba9cb9b6731ffd4b25b51fd126b6c3e05b99c"
+dependencies = [
+ "cfg-if 1.0.0",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,10 @@ version = "0.9.4"
 version = "0.4.11"
 features = ["std", "release_max_level_info"]
 
+[dependencies.prometheus]
+version = "0.12.0"
+default-features = false
+
 [dependencies.redis]
 optional = true
 version = "0.20.2"

--- a/src/agents/mailer/lettre_smtp.rs
+++ b/src/agents/mailer/lettre_smtp.rs
@@ -1,6 +1,6 @@
-use crate::agents::*;
 use crate::email_address::EmailAddress;
 use crate::utils::agent::*;
+use crate::{agents::*, metrics};
 use lettre::{
     smtp::authentication::Credentials, ClientSecurity, ClientTlsParameters, SmtpClient,
     SmtpTransport, Transport,
@@ -53,7 +53,12 @@ impl Agent for SmtpMailer {}
 impl Handler<SendMail> for SmtpMailer {
     fn handle(&mut self, message: SendMail, cx: Context<Self, SendMail>) {
         let mail = message.into_lettre_email(&self.from_address, &self.from_name);
-        match self.transport.send(mail) {
+
+        let send_timer = metrics::AUTH_EMAIL_SEND_DURATION.start_timer();
+        let res = self.transport.send(mail);
+        send_timer.observe_duration();
+
+        match res {
             Ok(result) => {
                 if result.is_positive() {
                     cx.reply(true);

--- a/src/agents/mailer/mailgun.rs
+++ b/src/agents/mailer/mailgun.rs
@@ -1,6 +1,6 @@
-use crate::agents::*;
 use crate::email_address::EmailAddress;
 use crate::utils::agent::*;
+use crate::{agents::*, metrics};
 use http::Request;
 use hyper::Body;
 use url::form_urlencoded;
@@ -55,7 +55,10 @@ impl Handler<SendMail> for MailgunMailer {
             .body(Body::from(body))
             .expect("Could not build Mailgun request");
 
-        let future = self.fetcher.send(FetchUrl { request });
+        let future = self.fetcher.send(FetchUrl {
+            request,
+            metric: &*metrics::AUTH_EMAIL_SEND_DURATION,
+        });
         cx.reply_later(async move {
             match future.await {
                 Ok(_) => true,

--- a/src/agents/mailer/mod.rs
+++ b/src/agents/mailer/mod.rs
@@ -5,6 +5,9 @@ use crate::utils::agent::Message;
 use ::{lettre::SendableEmail, lettre_email::EmailBuilder};
 
 /// Message requesting a mail be sent.
+///
+/// Handlers should also time the request using `metrics::AUTH_EMAIL_SEND_DURATION`, measuring the
+/// narrowest possible section of code that makes the external call.
 pub struct SendMail {
     pub to: EmailAddress,
     pub subject: String,

--- a/src/agents/mailer/postmark.rs
+++ b/src/agents/mailer/postmark.rs
@@ -1,6 +1,6 @@
-use crate::agents::*;
 use crate::email_address::EmailAddress;
 use crate::utils::agent::*;
+use crate::{agents::*, metrics};
 use http::Request;
 use hyper::Body;
 use serde::Deserialize;
@@ -57,7 +57,10 @@ impl Handler<SendMail> for PostmarkMailer {
             .body(Body::from(body))
             .expect("Could not build Postmark request");
 
-        let future = self.fetcher.send(FetchUrl { request });
+        let future = self.fetcher.send(FetchUrl {
+            request,
+            metric: &*metrics::AUTH_EMAIL_SEND_DURATION,
+        });
         cx.reply_later(async move {
             let data = match future.await {
                 Ok(result) => result.data,

--- a/src/agents/store/memory.rs
+++ b/src/agents/store/memory.rs
@@ -182,7 +182,9 @@ impl Handler<FetchUrlCached> for MemoryStore {
             if let Some(entry) = slot.as_ref().filter(|entry| entry.is_alive()) {
                 return Ok(entry.value.clone());
             }
-            let result = fetcher.send(FetchUrl::get(&message.url)).await?;
+            let result = fetcher
+                .send(FetchUrl::get(&message.url, message.metric))
+                .await?;
             let ttl = std::cmp::max(expire_cache, result.max_age);
             *slot = Some(Expiring::from_duration(result.data.clone(), ttl));
             Ok(result.data)

--- a/src/agents/store/mod.rs
+++ b/src/agents/store/mod.rs
@@ -4,6 +4,7 @@ use crate::crypto::SigningAlgorithm;
 use crate::utils::agent::{Addr, Message, Sender};
 use crate::utils::BoxError;
 use crate::web::Session;
+use prometheus::Histogram;
 use std::collections::HashSet;
 use url::Url;
 
@@ -40,6 +41,8 @@ impl Message for DeleteSession {
 pub struct FetchUrlCached {
     /// The URL to fetch.
     pub url: Url,
+    /// Latency metric to use on cache miss.
+    pub metric: &'static Histogram,
 }
 impl Message for FetchUrlCached {
     type Reply = Result<String, BoxError>;

--- a/src/agents/store/redis.rs
+++ b/src/agents/store/redis.rs
@@ -200,7 +200,9 @@ impl Handler<FetchUrlCached> for RedisStore {
                 Ok(data)
             } else {
                 let key = message.url.as_str().to_owned();
-                let result = fetcher.send(FetchUrl::get(&message.url)).await?;
+                let result = fetcher
+                    .send(FetchUrl::get(&message.url, message.metric))
+                    .await?;
                 let ttl = std::cmp::max(expire_cache, result.max_age);
                 conn.set_ex(key, result.data.clone(), ttl.as_secs() as usize)
                     .await?;

--- a/src/agents/store/rusqlite.rs
+++ b/src/agents/store/rusqlite.rs
@@ -276,7 +276,9 @@ impl Handler<FetchUrlCached> for RusqliteStore {
         let fetcher = self.fetcher.clone();
         let expire_cache = self.expire_cache;
         cx.reply_later(async move {
-            let result = fetcher.send(FetchUrl::get(&message.url.clone())).await?;
+            let result = fetcher
+                .send(FetchUrl::get(&message.url, message.metric))
+                .await?;
             let ttl = std::cmp::max(expire_cache, result.max_age);
             me.send(SaveCache {
                 url: message.url,

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ mod crypto;
 mod email_address;
 mod error;
 mod handlers;
+mod metrics;
 mod router;
 mod utils;
 mod validation;
@@ -141,6 +142,7 @@ async fn start_server(builder: ConfigBuilder) {
         .expect("Failed to signal ready to the service manager");
 
     let make_service = make_service_fn(|stream| {
+        metrics::HTTP_CONNECTIONS.inc();
         let app = ConfigRc::clone(&app);
         future::ok::<_, BoxError>(Service::new(app, stream))
     });

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,0 +1,108 @@
+use prometheus::{
+    register_histogram, register_int_counter, register_int_counter_vec, Histogram, IntCounter,
+    IntCounterVec,
+};
+
+lazy_static::lazy_static! {
+    pub static ref HTTP_CONNECTIONS: IntCounter = register_int_counter!(
+        "portier_http_connections",
+        "Number of HTTP connections accepted"
+    ).unwrap();
+
+    pub static ref HTTP_REQUESTS: IntCounter = register_int_counter!(
+        "portier_http_requests",
+        "Number of HTTP requests processed"
+    ).unwrap();
+
+    pub static ref HTTP_RESPONSE_STATUS: IntCounterVec = register_int_counter_vec!(
+        "portier_http_response_status",
+        "Number of HTTP responses by status category",
+        &["code"]
+    ).unwrap();
+    pub static ref HTTP_RESPONSE_STATUS_1XX: IntCounter =
+        HTTP_RESPONSE_STATUS.with_label_values(&["1xx"]);
+    pub static ref HTTP_RESPONSE_STATUS_2XX: IntCounter =
+        HTTP_RESPONSE_STATUS.with_label_values(&["2xx"]);
+    pub static ref HTTP_RESPONSE_STATUS_3XX: IntCounter =
+        HTTP_RESPONSE_STATUS.with_label_values(&["3xx"]);
+    pub static ref HTTP_RESPONSE_STATUS_4XX: IntCounter =
+        HTTP_RESPONSE_STATUS.with_label_values(&["4xx"]);
+    pub static ref HTTP_RESPONSE_STATUS_5XX: IntCounter =
+        HTTP_RESPONSE_STATUS.with_label_values(&["5xx"]);
+
+    pub static ref AUTH_LIMITED: IntCounter = register_int_counter!(
+        "portier_auth_limited",
+        "Number of rate-limited authentication requests"
+    ).unwrap();
+
+    pub static ref AUTH_REQUESTS: IntCounter = register_int_counter!(
+        "portier_auth_requests",
+        "Number of authentication requests"
+    ).unwrap();
+
+    pub static ref AUTH_WEBFINGER_DURATION: Histogram = register_histogram!(
+        "portier_auth_webfinger_duration",
+        "Latency of outgoing Webfinger requests."
+    ).unwrap();
+
+    pub static ref AUTH_EMAIL_REQUESTS: IntCounter = register_int_counter!(
+        "portier_auth_email_requests",
+        "Number of authentication requests that used email"
+    ).unwrap();
+
+    pub static ref AUTH_EMAIL_SEND_DURATION: Histogram = register_histogram!(
+        "portier_auth_email_send_duration",
+        "Latency of sending email"
+    ).unwrap();
+
+    pub static ref AUTH_EMAIL_COMPLETED: IntCounter = register_int_counter!(
+        "portier_auth_email_completed",
+        "Number of successful email authentications"
+    ).unwrap();
+
+    pub static ref AUTH_EMAIL_CODE_INCORRECT: IntCounter = register_int_counter!(
+        "portier_auth_email_code_incorrect",
+        "Number of email confirmation attempts with an invalid code"
+    ).unwrap();
+
+    pub static ref AUTH_OIDC_REQUESTS: IntCounterVec = register_int_counter_vec!(
+        "portier_auth_oidc_requests",
+        "Number of authentication requests that used OpenID Connect",
+        &["rel"]
+    ).unwrap();
+    pub static ref AUTH_OIDC_REQUESTS_PORTIER: IntCounter =
+        AUTH_OIDC_REQUESTS.with_label_values(&["portier"]);
+    pub static ref AUTH_OIDC_REQUESTS_GOOGLE: IntCounter =
+        AUTH_OIDC_REQUESTS.with_label_values(&["google"]);
+
+    pub static ref AUTH_OIDC_FETCH_CONFIG_DURATION: Histogram = register_histogram!(
+        "portier_auth_oidc_fetch_config_duration",
+        "Latency of outgoing requests for OpenID Connect configuration documents"
+    ).unwrap();
+
+    pub static ref AUTH_OIDC_FETCH_JWKS_DURATION: Histogram = register_histogram!(
+        "portier_auth_oidc_fetch_jwks_duration",
+        "Latency of outgoing requests for OpenID Connect JWKs"
+    ).unwrap();
+
+    pub static ref AUTH_OIDC_COMPLETED: IntCounter = register_int_counter!(
+        "portier_auth_oidc_completed",
+        "Number of successful OpenID Connect authentications"
+    ).unwrap();
+
+    pub static ref DOMAIN_VALIDATION_ERROR: IntCounterVec = register_int_counter_vec!(
+        "portier_domain_validation_error",
+        "Number of authentication requests for invalid domains",
+        &["reason"]
+    ).unwrap();
+    pub static ref DOMAIN_VALIDATION_INVALID_NAME: IntCounter =
+        DOMAIN_VALIDATION_ERROR.with_label_values(&["invalid_name"]);
+    pub static ref DOMAIN_VALIDATION_BLOCKED: IntCounter =
+        DOMAIN_VALIDATION_ERROR.with_label_values(&["blocked"]);
+    pub static ref DOMAIN_VALIDATION_NULL_MX: IntCounter =
+        DOMAIN_VALIDATION_ERROR.with_label_values(&["null_mx"]);
+    pub static ref DOMAIN_VALIDATION_NO_SERVERS: IntCounter =
+        DOMAIN_VALIDATION_ERROR.with_label_values(&["no_servers"]);
+    pub static ref DOMAIN_VALIDATION_NO_PUBLIC_IPS: IntCounter =
+        DOMAIN_VALIDATION_ERROR.with_label_values(&["no_public_ips"]);
+}

--- a/src/router.rs
+++ b/src/router.rs
@@ -26,6 +26,7 @@ pub async fn router(ctx: &mut Context) -> HandlerResult {
         // Misc endpoints
         (&Method::GET, "/") => handlers::pages::index(ctx).await,
         (&Method::GET, "/ver.txt") => handlers::pages::version(ctx).await,
+        (&Method::GET, "/metrics") => handlers::pages::metrics(ctx).await,
 
         // Lastly, fall back to trying to serve static files out of ./res/
         (&Method::GET, _) | (&Method::HEAD, _) => handlers::pages::static_(ctx).await,

--- a/src/webfinger.rs
+++ b/src/webfinger.rs
@@ -2,6 +2,7 @@ use crate::agents::FetchUrlCached;
 use crate::config::ConfigRc;
 use crate::email_address::EmailAddress;
 use crate::error::BrokerError;
+use crate::metrics;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Error as FmtError, Formatter};
 use std::str::FromStr;
@@ -120,7 +121,10 @@ pub async fn query(app: &ConfigRc, email_addr: &EmailAddress) -> Result<Vec<Link
     // Make the request.
     let descriptor = app
         .store
-        .send(FetchUrlCached { url })
+        .send(FetchUrlCached {
+            url,
+            metric: &*metrics::AUTH_WEBFINGER_DURATION,
+        })
         .await
         .map_err(|e| BrokerError::Provider(format!("webfinger request failed: {}", e)))?;
     let descriptor: DescriptorDef = serde_json::from_str(&descriptor)


### PR DESCRIPTION
This adds a Prometheus-compatible `GET /metrics` route. I specifically tried to add visibility into:

- Rate-limited requests
- Domain validation failures (because these now use actual DNS resolution)
- Latency of external calls (email / webfinger / oidc)

These metrics are public, so I've not used any identifying information.