### PR TITLE
Keys import / export

### DIFF
--- a/docs/key-management.md
+++ b/docs/key-management.md
@@ -79,3 +79,8 @@ _after_ keys from `keyfiles`.
 
 NOTE: Inputs are read during broker startup, and there is currently no way to
 reload configuration. Rotating keys manually requires restarting the broker.
+
+NOTE: When using manual keying, keys are served to clients with a
+`Cache-Control` header and `max-age` set according to the `keys_ttl` setting.
+When manually changing keys, keep in mind how long clients may be caching your
+public keys. (Proxies can be ignored, because we add `s-max-age=0`.)

--- a/docs/key-management.md
+++ b/docs/key-management.md
@@ -1,0 +1,81 @@
+# Private key management
+
+The broker uses a set of private keys for signing JSON Web Tokens. By default,
+these keys are managed automatically in the configured store.
+
+When managed automatically, private keys rotate according to `keys_ttl`. In
+practice, each key is valid for 3 times this duration, as the key is rotated
+through three steps: next, current, previous. These three steps allow our
+rotation to work well with client cache.
+
+## Generating RSA keys
+
+Currently, the broker is not capable of generating RSA keys by itself, and
+instead an external command is invoked when a new key must be generated. By
+default, this command is `openssl genrsa 2048`, but this can be customized
+using the `generate_rsa_command` configuration option. This option is
+documented in the [example configuration file].
+
+[example configuration file]: ../config.toml.dist
+
+## Import / export
+
+The broker provides import and export options for its private keys. These can
+be used to switch between stores, or switch to/from manual keying, to name some
+examples.
+
+To export private keys:
+
+```bash
+./portier-broker[.exe] --export-keys FILE
+```
+
+This command will write a series of PEM blocks to `FILE`, one for each private
+key in the store.
+
+To import private keys:
+
+```bash
+# 'Dry run' to test changes without applying them.
+./portier-broker[.exe] ./config.toml --import-keys FILE --dry-run
+# Import and apply changes.
+./portier-broker[.exe] ./config.toml --import-keys FILE
+```
+
+This command will read a series of PEM blocks from `FILE`, parse the private
+keys within, and save them in the store.
+
+NOTE: Expiration times are currently not preserved. When importing, expiration
+times are reset according to the `keys_ttl` setting.
+
+### PEM format
+
+If you are manually authoring a PEM file for `--import-keys`, note that the
+broker applies special meaning to the order of PEM blocks in the file.
+
+- Internally, the broker manages 'key sets', one for each kind of signing
+  algorithm used. The PEM file may interleave different types of keys, and only
+  the order among keys of the same type matters.
+
+- Between 0 and 3 keys of a type are expected, in the order: current, next,
+  previous. If zero of a type are present, that key set is left intact.
+  Otherwise, the key set for that type is entirely replaced.
+
+- Both PKCS#8 and unwrapped RSA DER keys are supported.
+
+## Manual keying
+
+If you instead wish to manually manage private keys for the broker, setting
+either of `keyfiles` and `keytext` will cause the broker to use keys in those
+files and disable automatic keying.
+
+The input must contain some PEM blocks, and at least one valid private key for
+each enabled signing algorithm. Both PKCS#8 and unwrapped RSA DER keys are
+supported. For signing, the broker uses the last key encountered of the type
+required by the signing algorithm.
+
+If `keyfiles` and `keytext` are both used, keys in `keytext` are ordered
+_after_ keys from `keyfiles`.
+
+NOTE: Inputs are read during broker startup, and there is currently no way to
+reload configuration. Rotating keys manually requires restarting the broker.

--- a/src/agents/key_manager/manual.rs
+++ b/src/agents/key_manager/manual.rs
@@ -9,16 +9,14 @@ use crate::utils::{
 use log::{info, warn};
 use ring::signature::{Ed25519KeyPair, RsaKeyPair};
 use std::fs::File;
-use std::io::BufReader;
+use std::io::{BufReader, Error as IoError};
 use std::path::PathBuf;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum ManualKeysError {
-    #[error("could not parse keytext: {0}")]
-    InvalidKeytext(#[from] pem::ParseError),
-    #[error("no PEM data found in keytext")]
-    EmptyKeytext,
+    #[error("could not read keyfile '{file}': {err}")]
+    IoError { file: PathBuf, err: IoError },
     #[error("no {} keys found in keyfiles or keytext", signing_alg)]
     MissingKeys { signing_alg: SigningAlgorithm },
 }
@@ -41,77 +39,64 @@ impl ManualKeys {
             "Using manual key management with algorithms: {}",
             SigningAlgorithm::format_list(signing_algs)
         );
+
         let mut parsed = vec![];
         for keyfile in keyfiles {
             let file = match File::open(keyfile) {
                 Ok(file) => file,
                 Err(err) => {
-                    warn!(
-                        "Ignoring keyfile '{}', could not open: {}",
-                        keyfile.display(),
-                        err
-                    );
+                    warn!("{}: ignoring, could not open: {}", keyfile.display(), err);
                     continue;
                 }
             };
-
-            let key_pairs = match pem::parse_key_pairs(BufReader::new(file)) {
-                Ok(key_pairs) => key_pairs,
-                Err(err) => {
-                    warn!(
-                        "Ignoring keyfile '{}', could not parse: {}",
-                        keyfile.display(),
-                        err
-                    );
-                    continue;
-                }
-            };
-
-            if key_pairs.is_empty() {
-                warn!(
-                    "Ignoring keyfile '{}', no PEM data found",
-                    keyfile.display()
-                );
-                continue;
-            }
-
-            let orig_len = key_pairs.len();
-            let mut key_pairs = key_pairs
-                .into_iter()
-                .filter(|key_pair| signing_algs.contains(&key_pair.signing_alg()))
-                .collect::<Vec<_>>();
-            if key_pairs.len() != orig_len {
-                warn!(
-                    "Ignoring {} (of {}) key(s) in '{}' for disabled signing algorithms",
-                    orig_len - key_pairs.len(),
-                    orig_len,
-                    keyfile.display()
-                );
-            }
-
-            parsed.append(&mut key_pairs);
+            let entries = pem::parse_key_pairs(BufReader::new(file)).map_err(|err| {
+                let file = keyfile.clone();
+                ManualKeysError::IoError { file, err }
+            })?;
+            let source = format!("{}", keyfile.display());
+            parsed.push((source, entries));
         }
         if let Some(keytext) = keytext {
-            let mut key_pairs = pem::parse_key_pairs(keytext.as_bytes())?;
-            if key_pairs.is_empty() {
-                return Err(ManualKeysError::EmptyKeytext);
-            }
-            parsed.append(&mut key_pairs);
+            let entries = pem::parse_key_pairs(keytext.as_bytes()).unwrap();
+            let source = "<keytext>".to_owned();
+            parsed.push((source, entries));
         }
 
         let mut ed25519_keys = vec![];
         let mut rsa_keys = vec![];
-        for key_pair in parsed {
-            match key_pair {
-                ParsedKeyPair::Ed25519(key_pair) => ed25519_keys.push(key_pair.into()),
-                ParsedKeyPair::Rsa(key_pair) => rsa_keys.push(key_pair.into()),
+        for (source, entries) in parsed {
+            if entries.is_empty() {
+                warn!("{}: ignoring, no PEM sections found", source);
+            }
+
+            for (idx, result) in entries.into_iter().enumerate() {
+                let idx = idx + 1;
+                let entry = match result {
+                    Ok(entry) => entry,
+                    Err(err) => {
+                        warn!("{} #{}: ignoring, {}", source, idx, err);
+                        continue;
+                    }
+                };
+
+                let alg = entry.key_pair.signing_alg();
+                if !signing_algs.contains(&alg) {
+                    warn!("{} #{}: ignoring, disabled signing algorithm", source, idx);
+                    continue;
+                }
+
+                match entry.key_pair {
+                    ParsedKeyPair::Ed25519(key_pair) => ed25519_keys.push(key_pair.into()),
+                    ParsedKeyPair::Rsa(key_pair) => rsa_keys.push(key_pair.into()),
+                }
+
+                let fp = entry.raw.fingerprint();
+                info!(
+                    "{} #{}: found {} key, fingerprint: {}",
+                    source, idx, alg, fp
+                );
             }
         }
-        info!(
-            "Found keys: {} Ed25519 key(s), {} RSA key(s)",
-            ed25519_keys.len(),
-            rsa_keys.len()
-        );
 
         for signing_alg in signing_algs {
             if match signing_alg {

--- a/src/agents/key_manager/manual.rs
+++ b/src/agents/key_manager/manual.rs
@@ -139,7 +139,10 @@ impl Handler<GetPublicJwks> for ManualKeys {
     fn handle(&mut self, _message: GetPublicJwks, cx: Context<Self, GetPublicJwks>) {
         let ed25519_jwks = self.ed25519_keys.iter().map(NamedKeyPair::public_jwk);
         let rsa_jwks = self.rsa_keys.iter().map(NamedKeyPair::public_jwk);
-        cx.reply(ed25519_jwks.chain(rsa_jwks).collect());
+        cx.reply(GetPublicJwksReply {
+            jwks: ed25519_jwks.chain(rsa_jwks).collect(),
+            expires: None,
+        });
     }
 }
 

--- a/src/agents/key_manager/mod.rs
+++ b/src/agents/key_manager/mod.rs
@@ -1,7 +1,11 @@
-use crate::crypto::SigningAlgorithm;
-use crate::utils::agent::{Message, Sender};
-use crate::utils::keys::SignError;
 use serde_json::Value as JsonValue;
+use std::time::SystemTime;
+
+use crate::crypto::SigningAlgorithm;
+use crate::utils::{
+    agent::{Message, Sender},
+    keys::SignError,
+};
 
 /// Message requesting a JSON payload to be signed.
 pub struct SignJws {
@@ -14,8 +18,12 @@ impl Message for SignJws {
 
 /// Message requesting a list of public JWKs.
 pub struct GetPublicJwks;
+pub struct GetPublicJwksReply {
+    pub jwks: Vec<JsonValue>,
+    pub expires: Option<SystemTime>,
+}
 impl Message for GetPublicJwks {
-    type Reply = Vec<JsonValue>;
+    type Reply = GetPublicJwksReply;
 }
 
 /// Key manager abstraction. Combines all message types.

--- a/src/agents/key_manager/rotating.rs
+++ b/src/agents/key_manager/rotating.rs
@@ -8,7 +8,6 @@ use crate::utils::{
 use ring::signature::{Ed25519KeyPair, RsaKeyPair};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
-use std::io::Cursor;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
@@ -118,13 +117,12 @@ impl<T: KeyPairExt + GeneratedKeyPair> ActiveKeySet<T> {
     }
 
     fn parse_one(pem: &str) -> T {
-        let mut key_pairs =
-            pem::parse_key_pairs(Cursor::new(pem)).expect("Could not parsed key as PEM");
-        if key_pairs.len() != 1 {
+        let mut entries = pem::parse_key_pairs(pem.as_bytes()).unwrap();
+        if entries.len() != 1 {
             panic!("Expected exactly one key in PEM");
         }
-        let key_pair = key_pairs.pop().unwrap();
-        T::from_parsed(key_pair).expect("Found key pair of incorrect type")
+        let entry = entries.pop().unwrap().expect("Could not parse key as PEM");
+        T::from_parsed(entry.key_pair).expect("Found key pair of incorrect type")
     }
 
     fn append_public_jwks(&self, vec: &mut Vec<serde_json::Value>) {

--- a/src/agents/store/memory.rs
+++ b/src/agents/store/memory.rs
@@ -316,4 +316,10 @@ impl Handler<ImportKeySet> for MemoryStore {
     }
 }
 
+impl Handler<ExportKeySet> for MemoryStore {
+    fn handle(&mut self, _message: ExportKeySet, _cx: Context<Self, ExportKeySet>) {
+        panic!("Exporting keys from a memory store has no effect");
+    }
+}
+
 impl StoreSender for Addr<MemoryStore> {}

--- a/src/agents/store/mod.rs
+++ b/src/agents/store/mod.rs
@@ -127,6 +127,14 @@ impl Message for ImportKeySet {
     type Reply = ();
 }
 
+/// Read a key set.
+///
+/// This is used to implement `--export-key`.
+pub struct ExportKeySet(pub SigningAlgorithm);
+impl Message for ExportKeySet {
+    type Reply = KeySet;
+}
+
 /// Store abstraction. Combines all message types.
 ///
 /// Downside of this is that it needs to be implemented on the agent side as:
@@ -143,6 +151,7 @@ pub trait StoreSender:
     + Sender<EnableRotatingKeys>
     + Sender<RotateKeysLocked>
     + Sender<ImportKeySet>
+    + Sender<ExportKeySet>
 {
 }
 

--- a/src/agents/store/redis.rs
+++ b/src/agents/store/redis.rs
@@ -381,6 +381,17 @@ impl Handler<ImportKeySet> for RedisStore {
     }
 }
 
+impl Handler<ExportKeySet> for RedisStore {
+    fn handle(&mut self, message: ExportKeySet, cx: Context<Self, ExportKeySet>) {
+        let me = cx.addr().clone();
+        cx.reply_later(async move {
+            me.send(FetchKeys(message.0))
+                .await
+                .expect("Failed to fetch keys from Redis")
+        });
+    }
+}
+
 impl Handler<LockKeys> for RedisStore {
     fn handle(&mut self, message: LockKeys, cx: Context<Self, LockKeys>) {
         let mut locking = self.locking.clone();

--- a/src/agents/store/rusqlite.rs
+++ b/src/agents/store/rusqlite.rs
@@ -480,6 +480,12 @@ impl Handler<ImportKeySet> for RusqliteStore {
     }
 }
 
+impl Handler<ExportKeySet> for RusqliteStore {
+    fn handle(&mut self, message: ExportKeySet, cx: Context<Self, ExportKeySet>) {
+        cx.reply(self.get_key_set(message.0));
+    }
+}
+
 impl Handler<SaveKeys> for RusqliteStore {
     fn handle(&mut self, message: SaveKeys, cx: Context<Self, SaveKeys>) {
         let key_set = message.0;

--- a/src/bridges/email.rs
+++ b/src/bridges/email.rs
@@ -96,13 +96,10 @@ pub async fn auth(ctx: &mut Context, email_addr: EmailAddress) -> HandlerResult 
 
     // Render a form for the user.
     if ctx.want_json {
-        Ok(json_response(
-            &json!({
-                "result": "verification_code_sent",
-                "session": &ctx.session_id,
-            }),
-            None,
-        ))
+        Ok(json_response(&json!({
+            "result": "verification_code_sent",
+            "session": &ctx.session_id,
+        })))
     } else {
         let catalog = ctx.catalog();
         Ok(html_response(ctx.app.templates.confirm_email.render(&[

--- a/src/bridges/mod.rs
+++ b/src/bridges/mod.rs
@@ -77,13 +77,10 @@ pub async fn complete_auth(ctx: &mut Context) -> HandlerResult {
     };
 
     if ctx.want_json {
-        Ok(json_response(
-            &json!({
-                auth_field: &auth_value,
-                "state": &state,
-            }),
-            None,
-        ))
+        Ok(json_response(&json!({
+            auth_field: &auth_value,
+            "state": &state,
+        })))
     } else {
         Ok(return_to_relier(
             ctx,

--- a/src/bridges/oidc.rs
+++ b/src/bridges/oidc.rs
@@ -204,13 +204,10 @@ pub async fn auth(ctx: &mut Context, email_addr: &EmailAddress, link: &Link) -> 
     }
 
     if ctx.want_json {
-        Ok(json_response(
-            &json!({
-                "result": "redirect_to_provider",
-                "url": auth_url.as_str(),
-            }),
-            None,
-        ))
+        Ok(json_response(&json!({
+            "result": "redirect_to_provider",
+            "url": auth_url.as_str(),
+        })))
     } else {
         let mut res = empty_response(StatusCode::SEE_OTHER);
         res.header(hyper::header::LOCATION, auth_url.as_str());

--- a/src/handlers/token.rs
+++ b/src/handlers/token.rs
@@ -56,12 +56,9 @@ pub async fn token(ctx: &mut Context) -> HandlerResult {
     .await
     .map_err(|err| BrokerError::Internal(format!("Could not create a JWT: {:?}", err)))?;
 
-    Ok(json_response(
-        &json!({
-            "access_token": "UNUSED",
-            "token_type": "bearer",
-            "id_token": &jwt,
-        }),
-        None,
-    ))
+    Ok(json_response(&json!({
+        "access_token": "UNUSED",
+        "token_type": "bearer",
+        "id_token": &jwt,
+    })))
 }

--- a/src/utils/keys.rs
+++ b/src/utils/keys.rs
@@ -194,7 +194,7 @@ impl GeneratedKeyPair for Ed25519KeyPair {
     fn generate(config: Self::Config) -> String {
         let doc =
             Self::generate_pkcs8(&config.generator).expect("could not generate Ed25519 key pair");
-        pem::from_der(doc.as_ref())
+        pem::encode(doc.as_ref(), pem::PKCS8)
     }
 
     fn from_parsed(parsed: ParsedKeyPair) -> Option<Self> {

--- a/src/web.rs
+++ b/src/web.rs
@@ -363,14 +363,11 @@ async fn handle_error(ctx: &Context, err: BrokerError) -> Response {
     let reference = err.log(Some(&ctx.app.rng)).await;
 
     if ctx.want_json {
-        let mut res = json_response(
-            &json!({
-                "error": err.oauth_error_code(),
-                "error_description": &format!("{}", err),
-                "reference": reference,
-            }),
-            None,
-        );
+        let mut res = json_response(&json!({
+            "error": err.oauth_error_code(),
+            "error_description": &format!("{}", err),
+            "reference": reference,
+        }));
         *res.status_mut() = err.http_status_code();
         return res;
     }
@@ -569,13 +566,10 @@ pub fn return_to_relier(ctx: &Context, params: &[(&str, &str)]) -> Response {
 ///
 /// Serializes the argument value to JSON and returns a HTTP 200 response
 /// code with the serialized JSON as the body.
-pub fn json_response(obj: &serde_json::Value, max_age: Option<Duration>) -> Response {
+pub fn json_response(obj: &serde_json::Value) -> Response {
     let body = serde_json::to_string_pretty(&obj).expect("unable to coerce JSON Value into string");
     let mut res = Response::new(Body::from(body));
     res.typed_header(ContentType::json());
-    if let Some(max_age) = max_age {
-        res.typed_header(CacheControl::new().with_public().with_max_age(max_age));
-    }
     res
 }
 


### PR DESCRIPTION
This PR adds the ability to import and export the full set of private keys in the broker store. Useful for migrating stores.

```bash
$ portier-broker ./config.toml --export-keys x.pem
Exported 5 private keys
```

```bash
$ portier-broker ./config.toml --import-keys x.pem
#1: found RS256 key, fingerprint: SHA256:rTStB2BTzS1H183n41gMXGgFzT7plSx82A4vuOckkqw= (as current, expires in 86400s)
#2: found RS256 key, fingerprint: SHA256:9YIZCzmAd4UodkMhwLIv9Ij3z0fI4Dc7LTcPFQBdbFQ= (as next, expires in 172800s)
#3: found RS256 key, fingerprint: SHA256:EACAs0O+PlDhyT1zPOUfEKtl35TseE76TrRmkKEVMGg= (as previous)
#4: found EdDSA key, fingerprint: SHA256:D1YK+5q+wsy3rjlwb2jvdCoCASz6+ay7U/gboMlXMNk= (as current, expires in 86400s)
#5: found EdDSA key, fingerprint: SHA256:Sq92b5h9tIhEv227Sq/JmPZf3QB8wSTmD40aZnMDvHo= (as next, expires in 172800s)
NOTE: Expiration times cannot be imported, and were reset
WARN   Storing sessions and keys in SQLite at: db.sqlite3
WARN   Please always double check this directory has secure permissions!
WARN   (This warning can't be fixed; it's a friendly reminder.)
Successfully imported EdDSA keys
Successfully imported RS256 keys
```

Small BC, because this renames `--import-key` to `--import-keys`. In practice, the same input should continue to work, we've just expanded to handling more input.

I also tweaked the `keys.json` response to use `Expires` if possible, instead of `Cache-Control` with `max-age`. This should make client caches more accurate, and reduce problems with proxies. For manual keying, we still use `max-age`, but at least set `s-max-age=0` to reduce problems with proxies.