### PR TITLE
Enable overflow checks in release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ mailgun = []
 name = "portier-broker"
 path = "src/main.rs"
 
+[profile.release]
+overflow-checks = true
+
 [dependencies]
 accept-language = "2.0.0"
 base64 = "0.13.0"


### PR DESCRIPTION
This is a random thought, but I overheard that the Rust toolchain on Android enables this by default in release builds. It seems like a sensible thing to do, especially for a security sensitive tool like Portier.

But beyond that, I haven't given this a whole lot of thought.