### PR TITLE
Audit latest release daily

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -17,10 +17,20 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
+    # Use the latest release tag, not the main branch.
+    # This way, we know when to create a new security release.
+    - name: Checkout latest release
+      run: |
+        set -xe
+        tag="$(git ls-remote --sort='-v:refname' origin 'v*' | head -n1 | cut -f2)"
+        git fetch origin "$tag"
+        git checkout FETCH_HEAD
+
     - name: Security audit
-      uses: actions-rs/audit-check@v1
+      uses: stephank/actions-rs-audit-check@main
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
+        generate-lockfile: false
 
   # Performs simple dependency upgrades automatically.
   # Creates (or updates) a PR, and enables automerging.


### PR DESCRIPTION
Instead of running `cargo audit` on the `main` branch, this runs it against the latest release. I want to try prevent that automatic updates of stuff on `main` causes us to miss issues with dependencies in our current release binaries.

I had to fork actions-rs stuff, because the maintainer is currently unavailable. Specifically, I added an option to skip `cargo generate-lockfile`, because I believe that updates dependency versions in the lockfile. That's exactly what we don't want, because we want to check dependency versions as used in the release binaries.