### PR TITLE
Improve email parsing for Lettre compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -970,6 +970,7 @@ dependencies = [
  "combine",
  "ctrlc",
  "docopt",
+ "email_address",
  "envy",
  "futures-util",
  "gettext",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,10 @@ features = ["std"]
 version = "3.2.1"
 features = ["termination"]
 
+[dependencies.email_address]
+version = "0.2.3"
+default-features = false
+
 [dependencies.hyper]
 version = "0.14.16"
 features = ["full"]

--- a/src/agents/mailer/mod.rs
+++ b/src/agents/mailer/mod.rs
@@ -4,7 +4,7 @@ use crate::email_address::EmailAddress;
 use crate::utils::agent::Message;
 
 #[cfg(feature = "lettre")]
-use ::lettre::message::{Message as LettreMessage, MultiPart};
+use ::lettre::message::{Mailbox, Message as LettreMessage, MultiPart};
 
 /// Message requesting a mail be sent.
 ///
@@ -34,11 +34,13 @@ impl SendMail {
                     .try_into()
                     .expect("Could not build mail From header"),
             )
-            .to(self
-                .to
-                .as_str()
-                .parse()
-                .expect("Could not build mail To header"))
+            .to(Mailbox::new(
+                None,
+                self.to
+                    .as_str()
+                    .parse()
+                    .expect("Could not build mail To header"),
+            ))
             .subject(self.subject)
             .multipart(MultiPart::alternative_plain_html(
                 self.text_body,


### PR DESCRIPTION
This adds validation using the `email_address` crate, which is what Lettre uses. This is on top of our existing validation. The crate has some additional checks that we don't do, like length checks on the local part and the domain part. Some of the simpler checks do overlap, so we delegate those now.

I suspect we were running into these missing checks later on when sending mail, based on reports from @tschaume. But at that point, we `.expect()` and crash.

In addition, it looks like we were converting our `EmailAddress` to Lettres`Mailbox` when sending, which also allows full name in the input string. We now instead convert to `Address`, hopefully eliminating any potential issues there.