### PR TITLE
Various non-code changes

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,4 @@
 # Create PRs to automatically upgrade dependencies.
-#
-# NOTE: Before Dependabot runs, we perform simple upgrades automatically using
-# the `daily.yml` workflow `upgrade-deps` job, which runs at 03:00 UTC.
 
 version: 2
 updates:
@@ -9,11 +6,13 @@ updates:
 - package-ecosystem: 'cargo'
   directory: '/'
   schedule:
-    interval: 'daily'
+    # NOTE: Before Dependabot runs, we perform simple upgrades automatically using
+    # the `upgrade_deps.yml` workflow, which runs at 03:00 UTC.
+    interval: 'weekly'
+    day: 'monday'
     time: '05:00'
 
 - package-ecosystem: 'github-actions'
   directory: '/'
   schedule:
     interval: 'daily'
-    time: '05:00'

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -2,10 +2,8 @@ name: Daily checks
 
 on:
   workflow_dispatch:
-  # NOTE: Dependabot runs after this workflow, at 05:00 UTC. By ensuring this
-  # workflow runs first, we can perform simple upgrades ahead of Dependabot.
   schedule:
-  - cron: '0 3 * * *'
+  - cron: '0 7 * * *'
 
 jobs:
 
@@ -31,53 +29,3 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         generate-lockfile: false
-
-  # Performs simple dependency upgrades automatically.
-  # Creates (or updates) a PR, and enables automerging.
-  # For larger upgrades, we use Dependabot.
-  upgrade-deps:
-    runs-on: ubuntu-latest
-    steps:
-
-    - name: Checkout
-      uses: actions/checkout@v3
-
-    - name: Install Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: '1.60'
-        profile: minimal
-        default: true
-
-    - name: Cache Rust
-      uses: actions/cache@v3
-      with:
-        path: ~/.cargo/registry
-        key: upgrade-deps-cargo
-
-    - name: Upgrade Rust deps
-      run: cargo update
-
-    - name: Install Nix
-      uses: cachix/install-nix-action@v20
-
-    - name: Upgrade Nix flake
-      run: nix flake update
-
-    - name: Create PR
-      id: cpr
-      uses: peter-evans/create-pull-request@v4
-      with:
-        # Use a bot token, so checks run on the PR.
-        token: ${{ secrets.BOT_GITHUB_TOKEN }}
-        author: 'r-stephank <ghbot@stephank.nl>'
-        committer: 'r-stephank <ghbot@stephank.nl>'
-        commit-message: "Update Cargo.lock"
-        title: "Update Cargo.lock"
-        branch: "auto/update-deps"
-
-    - name: Enable automerge
-      if: steps.cpr.outputs.pull-request-operation == 'created'
-      run: gh pr merge --merge --auto '${{ steps.cpr.outputs.pull-request-number }}'
-      env:
-        GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -78,7 +78,6 @@ jobs:
 
     - name: Enable automerge
       if: steps.cpr.outputs.pull-request-operation == 'created'
-      uses: peter-evans/enable-pull-request-automerge@v2
-      with:
-        token: ${{ secrets.BOT_GITHUB_TOKEN }}
-        pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
+      run: gh pr merge --merge --auto '${{ steps.cpr.outputs.pull-request-number }}'
+      env:
+        GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -49,14 +49,20 @@ jobs:
         profile: minimal
         default: true
 
-    - name: Cache
+    - name: Cache Rust
       uses: actions/cache@v3
       with:
         path: ~/.cargo/registry
         key: upgrade-deps-cargo
 
-    - name: Upgrade deps
+    - name: Upgrade Rust deps
       run: cargo update
+
+    - name: Install Nix
+      uses: cachix/install-nix-action@v20
+
+    - name: Upgrade Nix flake
+      run: nix flake update
 
     - name: Create PR
       id: cpr

--- a/.github/workflows/upgrade_deps.yml
+++ b/.github/workflows/upgrade_deps.yml
@@ -1,0 +1,60 @@
+# Performs simple dependency upgrades automatically.
+# Creates (or updates) a PR, and enables automerging.
+# For larger upgrades, we use Dependabot.
+
+name: Upgrade dependencies
+
+on:
+  workflow_dispatch:
+  # NOTE: Dependabot runs after this workflow, at 05:00 UTC. By ensuring this
+  # workflow runs first, we can perform simple upgrades ahead of Dependabot.
+  schedule:
+  - cron: '0 3 * * 1'
+
+jobs:
+  upgrade-deps:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: '1.60'
+        profile: minimal
+        default: true
+
+    - name: Cache Rust
+      uses: actions/cache@v3
+      with:
+        path: ~/.cargo/registry
+        key: upgrade-deps-cargo
+
+    - name: Upgrade Rust deps
+      run: cargo update
+
+    - name: Install Nix
+      uses: cachix/install-nix-action@v20
+
+    - name: Upgrade Nix flake
+      run: nix flake update
+
+    - name: Create PR
+      id: cpr
+      uses: peter-evans/create-pull-request@v4
+      with:
+        # Use a bot token, so checks run on the PR.
+        token: ${{ secrets.BOT_GITHUB_TOKEN }}
+        author: 'r-stephank <ghbot@stephank.nl>'
+        committer: 'r-stephank <ghbot@stephank.nl>'
+        commit-message: "Update Cargo.lock"
+        title: "Update Cargo.lock"
+        branch: "auto/update-deps"
+
+    - name: Enable automerge
+      if: steps.cpr.outputs.pull-request-operation == 'created'
+      run: gh pr merge --merge --auto '${{ steps.cpr.outputs.pull-request-number }}'
+      env:
+        GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,13 @@
 # Version control
 .git
 
+# Misc
+.direnv
+
 # Build products
 target
 node_modules
+result
 
 # Runtime files
 *.pem

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1679410443,
+        "narHash": "sha256-xDHO/jixWD+y5pmW5+2q4Z4O/I/nA4MAa30svnZKK+M=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c9ece0059f42e0ab53ac870104ca4049df41b133",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,55 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  };
+
+  outputs = { self, nixpkgs }:
+  let
+
+    inherit (nixpkgs) lib;
+
+    forEachSystem = f: lib.mapAttrs (system: f) nixpkgs.legacyPackages;
+
+    makeBrokerPackage = pkgs: buildType:
+      with pkgs;
+      rustPlatform.buildRustPackage {
+        name = "portier-broker";
+
+        src = ./.;
+        cargoLock.lockFile = ./Cargo.lock;
+
+        nativeBuildInputs = [ makeWrapper ];
+        buildInputs = lib.optional stdenv.isDarwin (
+          with darwin.apple_sdk.frameworks; [ Security ]
+        );
+
+        doCheck = true;
+        inherit buildType;
+
+        postInstall = ''
+          mkdir $out/data
+          cp -r ./res ./tmpl ./lang $out/data/
+          rm $out/data/lang/*.po
+
+          wrapProgram $out/bin/portier-broker \
+            --set-default BROKER_DATA_DIR $out/data
+        '';
+      };
+
+  in {
+
+    packages = forEachSystem (pkgs: rec {
+      default = makeBrokerPackage pkgs "release";
+      debug = makeBrokerPackage pkgs "debug";
+    });
+
+    devShells = forEachSystem (pkgs: {
+      default = with pkgs; mkShell {
+        nativeBuildInputs = [ git cargo-audit cargo-outdated ]
+          ++ (with rustPackages; [ rustc cargo rustfmt clippy ]);
+        buildInputs = self.packages.${pkgs.system}.default.buildInputs;
+      };
+    });
+
+  };
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+#![forbid(unsafe_code)]
 #![warn(clippy::pedantic)]
 #![allow(
     clippy::cast_possible_truncation,


### PR DESCRIPTION
These all don't really touch broker functionality.

- I'd like to switch our own server in public-infra to use flakes at some point, and I believe we can ditch a bunch of custom code if we just package this repo as a flake too.
- We already require no `unsafe` in the broker code, might as well enforce it with a `#[forbid(...)]`.
- The [peter-evans/enable-pull-request-automerge](https://github.com/peter-evans/enable-pull-request-automerge) action is no longer necessary. See the readme there.
- We don't really have to do automatic upgrades as frequently as we do. Cargo updates are almost everyday, and I'm adding Nix in this PR, which is almost guaranteed daily, which is a lot of churn. It also doesn't really help with the security check anymore, because that checks the latest release, not `main`. So I'd like to reduce it to weekly automatic upgrades.