### PR TITLE
Support Unix sockets via socket activation

### DIFF
--- a/.github/workflows/upgrade_deps.yml
+++ b/.github/workflows/upgrade_deps.yml
@@ -49,8 +49,8 @@ jobs:
         token: ${{ secrets.BOT_GITHUB_TOKEN }}
         author: 'r-stephank <ghbot@stephank.nl>'
         committer: 'r-stephank <ghbot@stephank.nl>'
-        commit-message: "Update Cargo.lock"
-        title: "Update Cargo.lock"
+        commit-message: "Update dependencies"
+        title: "Update dependencies"
         branch: "auto/update-deps"
 
     - name: Enable automerge

--- a/docs/systemd/portier-broker.socket
+++ b/docs/systemd/portier-broker.socket
@@ -5,14 +5,16 @@
 
 [Socket]
 
-# Bind to IPv4 on the loopback interface.
+# Bind to a Unix domain socket.
 #
-# Note that the broker currently only supports HTTP (not HTTPS). Using a front
-# proxy to provide HTTPS is recommended.
-#
-# Note also that the broker currently does not support listening on Unix
-# sockets, not even through socket activation.
-ListenStream=127.0.0.1:3333
+# Alternatively, you can bind directly to a TCP port, but note that the broker
+# only speaks HTTP (not HTTPS or HTTP/2). Using a front proxy to provide HTTPS
+# is recommended.
+ListenStream=/var/run/portier-broker.socket
+
+# Allow only Nginx to access the socket.
+SocketGroup=nginx
+SocketMode=0660
 
 [Install]
 WantedBy=sockets.target

--- a/src/web.rs
+++ b/src/web.rs
@@ -12,7 +12,6 @@ use futures_util::stream::StreamExt;
 use gettext::Catalog;
 use headers::{CacheControl, ContentType, Header, StrictTransportSecurity};
 use http::{HeaderMap, Method, StatusCode, Uri};
-use hyper::server::conn::AddrStream;
 use hyper::service::Service as HyperService;
 use hyper::Body;
 use log::info;
@@ -224,23 +223,21 @@ impl Context {
 pub type Request = hyper::Request<Body>;
 /// Standard response type.
 pub type Response = hyper::Response<Body>;
-/// Result type of handlers
+/// Result type of handlers.
 pub type HandlerResult = Result<Response, BrokerError>;
 
 /// HTTP service
 pub struct Service {
-    /// The application configuration
+    /// The application configuration.
     app: ConfigRc,
-    /// The client address
-    remote_addr: SocketAddr,
+    /// The client address. None if a Unix socket connection.
+    remote_addr: Option<SocketAddr>,
 }
 
 impl Service {
-    pub fn new(app: ConfigRc, stream: &AddrStream) -> Self {
-        Self {
-            app,
-            remote_addr: stream.remote_addr(),
-        }
+    pub fn new(app: &ConfigRc, remote_addr: Option<SocketAddr>) -> Self {
+        let app = app.clone();
+        Self { app, remote_addr }
     }
 
     async fn serve(ip: IpAddr, req: Request, app: ConfigRc) -> Result<Response, BoxError> {


### PR DESCRIPTION
This does a little more work in `start_server` that was previously done in Hyper, namely accepting connections. But I believe Hyper 1.0 will remove connection handling, so this is something we'd have to do any way.