### PR TITLE
Support `_login_hint` to actually provide a hint

### DIFF
--- a/res/static/confirm_email.js
+++ b/res/static/confirm_email.js
@@ -1,0 +1,4 @@
+document.querySelector('input[name="code"]').addEventListener('paste', function(ev) {
+  ev.preventDefault();
+  this.value = ev.clipboardData.getData('text/plain').trim()
+});

--- a/res/static/login_hint.js
+++ b/res/static/login_hint.js
@@ -1,0 +1,7 @@
+document.addEventListener('DOMContentLoaded', function() {
+  // move the cursor to the end of the value
+  const input = document.querySelector('input[name="login_hint"]');
+  const value = input.value;
+  input.value = '';
+  input.value = value;
+});

--- a/tmpl/confirm_email.mustache
+++ b/tmpl/confirm_email.mustache
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Portier &ndash; {{ title }}</title>
     <link rel="stylesheet" href="/static/style.css">
+    <script src="/static/confirm_email.js" defer></script>
   </head>
   <body>
     <div class="container">

--- a/tmpl/login_hint.mustache
+++ b/tmpl/login_hint.mustache
@@ -6,6 +6,7 @@
     <link rel="stylesheet" href="/static/style.css">
     <title>Portier &ndash; {{ title }} {{ display_origin }}</title>
     <link rel="icon" type="image/svg+xml" href="/static/portier_p.min.svg">
+    <script src="/static/login_hint.js" defer></script>
   </head>
   <body>
     <div class="container">
@@ -23,7 +24,7 @@
             {{# params }}
               <input type="hidden" name="{{ name }}" value="{{ value }}">
             {{/ params }}
-            <input type="email" name="login_hint" autofocus autocomplete="off" autocorrect="off" autocapitalize="off"><button type="submit">Login</button>
+            <input type="email" name="login_hint" autofocus autocomplete="off" autocorrect="off" autocapitalize="off" value="{{ pre_login_hint }}"><button type="submit">Login</button>
           </form>
         </div>
       </main>

--- a/tmpl/login_hint.mustache
+++ b/tmpl/login_hint.mustache
@@ -23,7 +23,7 @@
             {{# params }}
               <input type="hidden" name="{{ name }}" value="{{ value }}">
             {{/ params }}
-            <input type="text" name="login_hint" autofocus autocomplete="off" autocorrect="off" autocapitalize="off"><button type="submit">Login</button>
+            <input type="email" name="login_hint" autofocus autocomplete="off" autocorrect="off" autocapitalize="off"><button type="submit">Login</button>
           </form>
         </div>
       </main>


### PR DESCRIPTION
There are occasions where you want to provide `login_hint` but not have Portier auto submit the request and start the authentication for you.

My scenario is:
 * use Portier as the login landing page
 * application wants to auto-fill in the email address field with the last used email address
 * user has multiple hats (email addresses and thus authorised for different things) at an organisation so may wish to use a different one than they did last time

This PR does the following:
 1. make all parameters passed prepended with `_` (underscore) for private use by Portier
 2. if `_login_hint` is set, this is displayed in the `<input name="login_hint" ...>` form field
      * ~~annoyingly we cannot automatically move the cursor to the end without JS (and amending the HTML documents CSP) but I am okay with this~~ just added some JS to do this
 3. whilst in here, opportunistically update the input field from type `text` to [`email` to provide client side validation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/email)

This is the first time I have ever touched Rust, so forgive me for the ugly conditional or two in here :)

Not a problem if you wish to close the PR as this is something you do not want to accept, or for you to cherry-pick or take inspiration from to roll your own better version.