### PR TITLE
Improve compliance with OIDC spec

### DIFF
--- a/src/bridges/mod.rs
+++ b/src/bridges/mod.rs
@@ -29,7 +29,6 @@ pub async fn complete_auth(ctx: &mut Context) -> HandlerResult {
         .await
         .map_err(|e| BrokerError::Internal(format!("could not remove a session: {e}")))?;
 
-    let state = data.return_params.state.clone();
     let origin = data
         .return_params
         .redirect_uri
@@ -79,13 +78,10 @@ pub async fn complete_auth(ctx: &mut Context) -> HandlerResult {
     if ctx.want_json {
         Ok(json_response(&json!({
             auth_field: &auth_value,
-            "state": &state,
+            "state": &ctx.return_params.as_ref().unwrap().state,
         })))
     } else {
-        Ok(return_to_relier(
-            ctx,
-            &[(auth_field, &auth_value), ("state", &state)],
-        ))
+        Ok(return_to_relier(ctx, &[(auth_field, &auth_value)]))
     }
 }
 

--- a/src/bridges/oidc.rs
+++ b/src/bridges/oidc.rs
@@ -238,7 +238,12 @@ pub async fn callback(ctx: &mut Context) -> HandlerResult {
     match params.get("error").map(String::as_str).unwrap_or_default() {
         "" => {}
         // We forward prompt=none, and expect certain errors.
-        "interaction_required" | "login_required" => return Err(BrokerError::InteractionRequired),
+        "interaction_required" | "login_required" => {
+            return Err(BrokerError::SpecificInput {
+                error: params.remove("error").unwrap(),
+                error_description: params.remove("error_description").unwrap_or_default(),
+            })
+        }
         err => {
             return Err(BrokerError::Provider(format!(
                 "provider returned error: {err}"

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -238,7 +238,7 @@ pub async fn create_jwt(
     email: &str,
     email_addr: &EmailAddress,
     aud: &str,
-    nonce: &str,
+    nonce: &Option<String>,
     signing_alg: SigningAlgorithm,
 ) -> Result<String, SignError> {
     let now = unix_duration();

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -254,6 +254,7 @@ pub async fn create_jwt(
                 "iss": &app.public_url,
                 "sub": email_addr.as_str(),
                 "nonce": nonce,
+                "auth_time": now.as_secs(),
             }),
             signing_alg,
         })

--- a/src/handlers/auth.rs
+++ b/src/handlers/auth.rs
@@ -181,7 +181,11 @@ pub async fn auth(ctx: &mut Context) -> HandlerResult {
     let login_hint = try_get_input_param!(params, "login_hint", String::new());
     if login_hint.is_empty() && !ctx.want_json {
         if prompt == "none" {
-            return Err(BrokerError::InteractionRequired);
+            return Err(BrokerError::SpecificInput {
+                error: "interaction_required".to_owned(),
+                error_description: "prompt disabled, but no email specified in login_hint"
+                    .to_owned(),
+            });
         }
 
         let display_origin = redirect_uri_.origin().unicode_serialization();
@@ -329,7 +333,10 @@ pub async fn auth(ctx: &mut Context) -> HandlerResult {
 
     // Fall back to email loop auth.
     if prompt == "none" {
-        return Err(BrokerError::InteractionRequired);
+        return Err(BrokerError::SpecificInput {
+            error: "interaction_required".to_owned(),
+            error_description: "prompt disabled, but email verification is required".to_owned(),
+        });
     }
     bridges::email::auth(ctx, email_addr).await
 }

--- a/src/handlers/token.rs
+++ b/src/handlers/token.rs
@@ -31,7 +31,10 @@ pub async fn token(ctx: &mut Context) -> HandlerResult {
         .map_err(|e| {
             BrokerError::Internal(format!("could not lookup the authorization code: {e}"))
         })?
-        .ok_or_else(|| BrokerError::ProviderInput("invalid authorization code".to_owned()))?;
+        .ok_or_else(|| BrokerError::SpecificInput {
+            error: "invalid_grant".to_owned(),
+            error_description: "invalid authorization code".to_owned(),
+        })?;
 
     if data.return_params.redirect_uri.as_str() != redirect_uri {
         return Err(BrokerError::ProviderInput(

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,7 +57,7 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 /// Defines the program's usage string.
 ///
 /// [Docopt](http://docopt.org) parses this and generates a custom argv parser.
-const USAGE: &str = r#"
+const USAGE: &str = r"
 Portier Broker
 
 Usage:
@@ -75,7 +75,7 @@ Options:
   --dry-run           Parse PEM to be imported, but don't apply changes
 
   --export-keys FILE  Export currently active private keys as PEM
-"#;
+";
 
 /// Holds parsed command line parameters.
 #[derive(Deserialize)]

--- a/src/web.rs
+++ b/src/web.rs
@@ -367,9 +367,9 @@ async fn handle_error(ctx: &Context, err: BrokerError) -> Response {
         // Redirects with description.
         (
             err @ (BrokerError::Input(_)
+            | BrokerError::SpecificInput { .. }
             | BrokerError::Provider(_)
-            | BrokerError::ProviderInput(_)
-            | BrokerError::InteractionRequired),
+            | BrokerError::ProviderInput(_)),
             true,
         ) => return_to_relier(
             ctx,
@@ -379,7 +379,7 @@ async fn handle_error(ctx: &Context, err: BrokerError) -> Response {
             ],
         ),
         // Friendly error pages for what we can't redirect.
-        (err @ (BrokerError::Input(_) | BrokerError::InteractionRequired), false) => {
+        (err @ (BrokerError::Input(_) | BrokerError::SpecificInput { .. }), false) => {
             let mut res = html_response(ctx.app.templates.error.render(&[
                 ("error", &format!("{err}")),
                 ("intro", catalog.gettext("The request is invalid, and could not be completed.")),

--- a/src/web.rs
+++ b/src/web.rs
@@ -42,11 +42,9 @@ pub struct Session {
 /// Response types we support.
 #[derive(Clone, Copy, Serialize, Deserialize)]
 pub enum ResponseType {
-    #[serde(rename = "id_token")]
     IdToken,
     // NOTE: This type is outside the Portier spec, but we support it in this implementation for
     // compatibility with other OpenID Connect clients.
-    #[serde(rename = "code")]
     Code,
 }
 
@@ -63,25 +61,11 @@ impl ResponseType {
 /// Response modes we support.
 #[derive(Clone, Copy, Serialize, Deserialize)]
 pub enum ResponseMode {
-    #[serde(rename = "fragment")]
     Fragment,
-    #[serde(rename = "form_post")]
     FormPost,
     // NOTE: This mode is outside the Portier spec, but we support it in this implementation for
     // compatibility with other OpenID Connect clients.
-    #[serde(rename = "query")]
     Query,
-}
-
-impl ResponseMode {
-    /// Return the querystring value for this response mode.
-    pub fn as_str(&self) -> &str {
-        match self {
-            ResponseMode::Fragment => "fragment",
-            ResponseMode::FormPost => "form_post",
-            ResponseMode::Query => "query",
-        }
-    }
 }
 
 /// Parameters used to return to the relying party
@@ -101,7 +85,7 @@ pub struct SessionData {
     pub email: String,
     pub email_addr: EmailAddress,
     pub response_type: ResponseType,
-    pub nonce: String,
+    pub nonce: Option<String>,
     pub signing_alg: SigningAlgorithm,
 }
 
@@ -156,7 +140,7 @@ impl Context {
         email: &str,
         email_addr: &EmailAddress,
         response_type: ResponseType,
-        nonce: &str,
+        nonce: Option<String>,
         signing_alg: SigningAlgorithm,
         ip: IpAddr,
     ) {
@@ -173,7 +157,7 @@ impl Context {
             email: email.to_owned(),
             email_addr: email_addr.clone(),
             response_type,
-            nonce: nonce.to_owned(),
+            nonce,
             signing_alg,
         });
     }

--- a/src/web.rs
+++ b/src/web.rs
@@ -382,8 +382,10 @@ async fn handle_error(ctx: &Context, err: BrokerError) -> Response {
     match (err, can_redirect) {
         // Redirects with description.
         (
-            err
-            @ (BrokerError::Input(_) | BrokerError::Provider(_) | BrokerError::ProviderInput(_)),
+            err @ (BrokerError::Input(_)
+            | BrokerError::Provider(_)
+            | BrokerError::ProviderInput(_)
+            | BrokerError::InteractionRequired),
             true,
         ) => return_to_relier(
             ctx,
@@ -393,7 +395,7 @@ async fn handle_error(ctx: &Context, err: BrokerError) -> Response {
             ],
         ),
         // Friendly error pages for what we can't redirect.
-        (err @ BrokerError::Input(_), false) => {
+        (err @ (BrokerError::Input(_) | BrokerError::InteractionRequired), false) => {
             let mut res = html_response(ctx.app.templates.error.render(&[
                 ("error", &format!("{err}")),
                 ("intro", catalog.gettext("The request is invalid, and could not be completed.")),

--- a/src/web.rs
+++ b/src/web.rs
@@ -40,7 +40,7 @@ pub struct Session {
 }
 
 /// Response types we support.
-#[derive(Clone, Copy, Serialize, Deserialize)]
+#[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ResponseType {
     IdToken,
     // NOTE: This type is outside the Portier spec, but we support it in this implementation for


### PR DESCRIPTION
This PR improves our score on OIDC self-certification for `oidcc-basic-certification-test-plan`. Full compliance may be outside the scope of the broker, up for discussion. IMO, it seems like we'd have to add a bunch of complexity for little benefit.

Where we still fail:
- We don't implement userinfo, and the entire test suite depends on it, despite it being optional. Fundamental is that we don't have access tokens at all, so we'd have to add storage for those if we want to do that. I've been cheating the test by doing 'access token = email', but that doesn't sound smart for production. It gives an illusion our 'access tokens' / sessions are permanently valid (and there are other tests in the test suite we'd fail any way.)
- We partially fail `oidcc-prompt-none-logged-in`. We forward `prompt=none` when bridging to OIDC, so it should work in those cases, but it'll never work for the email loop, because the broker doesn't have login sessions.
- We probably fail `oidcc-max-age-10000` even for OIDC bridging, because `max_age` is not forwarded. (But I only tested the email loop in general.)
- We fail `oidcc-id-token-hint`, because we don't implement `id_token_hint` at all. I considered returning the hint as-is to the RP if it was still valid, but that idea ran into a wall. I think we could still do this by issuing a new token with the same `exp`, but we'd have to track it in a number of places.
- We fail `oidcc-ensure-registered-redirect-uri` and `oidcc-ensure-request-object-with-redirect-uri`, because we allow any redirect URI in the client origin. The test suite expects specific redirect URIs that were registered only, but we have no registration.
- We fail `oidcc-server-client-secret-post` because we have no registration and thus no client secret.
- We fail `oidcc-refresh-token` because we don't have access tokens or refresh tokens.