### PR TITLE
Use AWS Libcrypto to generate RSA keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,12 +308,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "base64ct"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
-
-[[package]]
 name = "bindgen"
 version = "0.69.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -475,12 +469,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const-oid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -538,23 +526,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 
 [[package]]
-name = "der"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
-dependencies = [
- "const-oid",
- "zeroize",
-]
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
- "const-oid",
  "crypto-common",
 ]
 
@@ -1345,9 +1322,6 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-dependencies = [
- "spin 0.5.2",
-]
 
 [[package]]
 name = "lazycell"
@@ -1398,12 +1372,6 @@ dependencies = [
  "cfg-if",
  "windows-targets 0.52.5",
 ]
-
-[[package]]
-name = "libm"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -1587,53 +1555,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint-dig"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
-dependencies = [
- "byteorder",
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand",
- "smallvec",
- "zeroize",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
-dependencies = [
- "autocfg",
- "libm",
-]
-
-[[package]]
 name = "num_cpus"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1787,27 +1708,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pkcs1"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
-dependencies = [
- "der",
- "pkcs8",
- "spki",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der",
- "spki",
-]
-
-[[package]]
 name = "pkg-config"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1875,10 +1775,8 @@ dependencies = [
  "log 0.4.21",
  "mustache",
  "percent-encoding",
- "rand_core",
  "redis",
  "reqwest",
- "rsa",
  "rusqlite",
  "rustls 0.23.5",
  "serde",
@@ -2081,29 +1979,9 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "libc",
- "spin 0.9.8",
+ "spin",
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rsa"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0e5124fcb30e76a7e79bfee683a2746db83784b86289f6251b54b7950a0dfc"
-dependencies = [
- "const-oid",
- "digest",
- "num-bigint-dig",
- "num-integer",
- "num-traits",
- "pkcs1",
- "pkcs8",
- "rand_core",
- "signature",
- "spki",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -2359,16 +2237,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signature"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
-dependencies = [
- "digest",
- "rand_core",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2405,25 +2273,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
-
-[[package]]
-name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-
-[[package]]
-name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der",
-]
 
 [[package]]
 name = "stacker"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,14 +11,13 @@ rust-version = "1.72"
 edition = "2021"
 
 [features]
-default = ["rustls", "rsa", "redis", "rusqlite", "lettre_smtp", "lettre_sendmail", "postmark", "mailgun", "sendgrid"]
+default = ["rustls", "redis", "rusqlite", "lettre_smtp", "lettre_sendmail", "postmark", "mailgun", "sendgrid"]
 insecure = []
 lettre_smtp = ["lettre", "lettre/smtp-transport"]
 lettre_sendmail = ["lettre", "lettre/sendmail-transport"]
 postmark = []
 mailgun = []
 native-tls = ["hyper-tls", "reqwest/native-tls", "lettre?/native-tls"]
-rsa = ["dep:rsa", "rand_core"]
 rustls = ["dep:rustls", "hyper-rustls", "reqwest/rustls-tls-native-roots", "lettre?/rustls-tls", "lettre?/rustls-native-certs"]
 sendgrid = []
 
@@ -90,10 +89,6 @@ features = ["builder"]
 version = "0.4.11"
 features = ["std", "release_max_level_info"]
 
-[dependencies.rand_core]
-optional = true
-version = "0.6.4"
-
 [dependencies.redis]
 optional = true
 version = "0.25.3"
@@ -111,11 +106,6 @@ features = ["macos-system-configuration"]
 [dependencies.ring]
 package = "aws-lc-rs"
 version = "1.6.4"
-
-[dependencies.rsa]
-optional = true
-version = "0.9.0"
-default-features = false
 
 [dependencies.rusqlite]
 optional = true
@@ -142,7 +132,3 @@ features = ["tokio-runtime"]
 [dependencies.url]
 version = "2.1.1"
 features = ["serde"]
-
-# Per `rsa` crate docs, significantly speeds up key generation for debug builds.
-[profile.dev.package.num-bigint-dig]
-opt-level = 3

--- a/src/config/env.rs
+++ b/src/config/env.rs
@@ -223,6 +223,9 @@ impl EnvConfig {
         }
         if let Some(val) = parsed.generate_rsa_command {
             builder.generate_rsa_command = val.split_whitespace().map(ToOwned::to_owned).collect();
+            log::warn!(
+                "BROKER_GENERATE_RSA_COMMAND is deprecated and will be removed in a future release.",
+            );
         }
 
         if let Some(val) = parsed.redis_url {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -474,14 +474,7 @@ impl ConfigBuilder {
             keytext: None,
             signing_algs: vec![SigningAlgorithm::Rs256],
             rsa_modulus_bits: 2048,
-            generate_rsa_command: if cfg!(feature = "rsa") {
-                vec![]
-            } else {
-                "openssl genrsa 2048"
-                    .split_whitespace()
-                    .map(ToOwned::to_owned)
-                    .collect()
-            },
+            generate_rsa_command: vec![],
 
             redis_url: None,
             sqlite_db: None,
@@ -616,12 +609,6 @@ impl ConfigBuilder {
             )?;
             Box::new(spawn_agent(key_manager).await)
         } else {
-            if !cfg!(feature = "rsa")
-                && self.signing_algs.contains(&SigningAlgorithm::Rs256)
-                && self.generate_rsa_command.is_empty()
-            {
-                return Err("generate_rsa_command is required for rotating RSA keys".into());
-            }
             let key_manager = RotatingKeys::new(
                 store.clone(),
                 self.keys_ttl,

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -359,6 +359,9 @@ impl TomlConfig {
         }
         if let Some(val) = parsed.generate_rsa_command {
             builder.generate_rsa_command = val;
+            log::warn!(
+                "generate_rsa_command is deprecated and will be removed in a future release.",
+            );
         }
 
         if let Some(val) = parsed.redis_url {

--- a/src/utils/rng.rs
+++ b/src/utils/rng.rs
@@ -30,28 +30,3 @@ impl SecureRandom {
             .expect("secure random number generator panicked")
     }
 }
-
-#[cfg(feature = "rand_core")]
-impl rand_core::RngCore for SecureRandom {
-    fn next_u32(&mut self) -> u32 {
-        rand_core::impls::next_u32_via_fill(self)
-    }
-
-    fn next_u64(&mut self) -> u64 {
-        rand_core::impls::next_u64_via_fill(self)
-    }
-
-    fn fill_bytes(&mut self, dest: &mut [u8]) {
-        self.try_fill_bytes(dest)
-            .expect("secure random number generator failed");
-    }
-
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
-        self.generator
-            .fill(dest)
-            .map_err(|_| rand_core::Error::new("secure random number generator failed"))
-    }
-}
-
-#[cfg(feature = "rand_core")]
-impl rand_core::CryptoRng for SecureRandom {}


### PR DESCRIPTION
Since we switched from Ring to AWS Libcrypto, following Rustls, we already have a lib capable of generating RSA keys, and no longer have a use for the rust-crypto `rsa` crate.

We can probably remove the 'external command' method of generating RSA keys in the near feature, and move key size parsing to the config modules, so it is caught during startup.