### PR TITLE
Remove ring alias

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,11 +100,7 @@ version = "0.12.3"
 default-features = false
 features = ["macos-system-configuration"]
 
-# Alias ring -> aws-lc-rs.
-# Both are nearly API compatible, and Rustls also switched backends.
-# Going along with rustls means we can drop the ring dependency.
-[dependencies.ring]
-package = "aws-lc-rs"
+[dependencies.aws-lc-rs]
 version = "1.6.4"
 
 [dependencies.rusqlite]

--- a/src/agents/key_manager/manual.rs
+++ b/src/agents/key_manager/manual.rs
@@ -6,8 +6,8 @@ use crate::utils::{
     pem::{self, ParsedKeyPair},
     SecureRandom,
 };
+use aws_lc_rs::signature::{Ed25519KeyPair, RsaKeyPair};
 use log::{info, warn};
-use ring::signature::{Ed25519KeyPair, RsaKeyPair};
 use std::fs::File;
 use std::io::{BufReader, Error as IoError};
 use std::path::PathBuf;

--- a/src/agents/key_manager/rotating.rs
+++ b/src/agents/key_manager/rotating.rs
@@ -6,7 +6,7 @@ use crate::utils::{
     keys::{GeneratedKeyPair, KeyPairExt, NamedKeyPair, SignError},
     pem, DelayQueueTask, SecureRandom,
 };
-use ring::signature::{Ed25519KeyPair, RsaKeyPair};
+use aws_lc_rs::signature::{Ed25519KeyPair, RsaKeyPair};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::sync::Arc;

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -3,7 +3,7 @@ use crate::bridges::oidc::ProviderKey;
 use crate::config::Config;
 use crate::email_address::EmailAddress;
 use crate::utils::{base64url, keys::SignError, unix_duration, SecureRandom};
-use ring::{
+use aws_lc_rs::{
     digest,
     error::Unspecified,
     signature::{self, UnparsedPublicKey},

--- a/src/utils/keys.rs
+++ b/src/utils/keys.rs
@@ -4,7 +4,7 @@ use crate::utils::{
     pem::{self, ParsedKeyPair},
     SecureRandom,
 };
-use ring::{
+use aws_lc_rs::{
     digest,
     encoding::AsDer,
     rsa,
@@ -23,8 +23,8 @@ pub enum SignError {
     Unspecified,
 }
 
-impl From<ring::error::Unspecified> for SignError {
-    fn from(_: ring::error::Unspecified) -> Self {
+impl From<aws_lc_rs::error::Unspecified> for SignError {
+    fn from(_: aws_lc_rs::error::Unspecified) -> Self {
         Self::Unspecified
     }
 }

--- a/src/utils/pem.rs
+++ b/src/utils/pem.rs
@@ -2,11 +2,11 @@
 
 use std::io::{BufRead, Error as IoError, Read};
 
-use base64::prelude::*;
-use ring::{
+use aws_lc_rs::{
     digest::{digest, SHA256},
     signature::{Ed25519KeyPair, RsaKeyPair},
 };
+use base64::prelude::*;
 use thiserror::Error;
 
 use crate::{crypto::SigningAlgorithm, utils::keys::KeyPairExt};
@@ -76,7 +76,7 @@ pub enum ParseError {
     #[error("invalid base64: {0}")]
     Base64(#[from] base64::DecodeError),
     #[error("invalid private key: {0}")]
-    KeyRejected(ring::error::KeyRejected),
+    KeyRejected(aws_lc_rs::error::KeyRejected),
 }
 
 enum State {

--- a/src/utils/rng.rs
+++ b/src/utils/rng.rs
@@ -1,4 +1,4 @@
-use ring::rand::{SecureRandom as GeneratorTrait, SystemRandom};
+use aws_lc_rs::rand::{SecureRandom as GeneratorTrait, SystemRandom};
 use tokio::task::spawn_blocking;
 
 #[derive(Clone)]


### PR DESCRIPTION
This simply removes the `ring` alias, and instead uses `aws-lc-rs` directly.