### PR TITLE
Suppress auto responses from MS Exchange

### DIFF
--- a/src/agents/mailer/mailgun.rs
+++ b/src/agents/mailer/mailgun.rs
@@ -59,6 +59,7 @@ impl Handler<SendMail> for MailgunMailer {
             .append_pair("subject", &message.subject)
             .append_pair("html", &message.html_body)
             .append_pair("text", &message.text_body)
+            .append_pair("h:X-Auto-Response-Suppress", "All")
             .append_pair("h:List-Id", &self.list_id)
             .finish();
 

--- a/src/agents/mailer/mod.rs
+++ b/src/agents/mailer/mod.rs
@@ -51,7 +51,11 @@ impl SendMail {
             ))
             .expect("Could not build mail");
 
-        // Add a List-Id header to prevent autoresponders.
+        // Add headers to hint autoresponders.
+        msg.headers_mut().insert_raw(HeaderValue::new(
+            HeaderName::new_from_ascii_str("X-Auto-Response-Suppress"),
+            "All".to_string(),
+        ));
         msg.headers_mut().insert_raw(HeaderValue::new(
             HeaderName::new_from_ascii_str("List-Id"),
             format!("Authentication <auth.{}>", from_address.domain()),

--- a/src/agents/mailer/postmark.rs
+++ b/src/agents/mailer/postmark.rs
@@ -43,6 +43,10 @@ impl PostmarkMailer {
             from: format!("{from_name} <{from_address}>"),
             headers: json!([
                 {
+                    "Name": "X-Auto-Response-Suppress",
+                    "Value": "All",
+                },
+                {
                     "Name": "List-Id",
                     "Value": format!("Authentication <auth.{}>", from_address.domain()),
                 },

--- a/src/agents/mailer/sendgrid.rs
+++ b/src/agents/mailer/sendgrid.rs
@@ -36,6 +36,7 @@ impl SendgridMailer {
             api,
             from: json!({ "name": from_name, "email": from_address }),
             headers: json!({
+                "X-Auto-Response-Suppress": "All",
                 "List-Id": format!("Authentication <auth.{}>", from_address.domain()),
             }),
             timeout,


### PR DESCRIPTION
We added `List-Id` in the past, but it appears MS Exchange ignores this and instead looks for `X-Auto-Response-Suppress`. This PR adds that header.