### PR TITLE
Fixes to the contributed GCP deployment

### DIFF
--- a/contrib/gcp/README.md
+++ b/contrib/gcp/README.md
@@ -38,9 +38,9 @@ Baseline costs are ~$80/month when idle:
 You will need to already have have a GCP account, created a project with an billing account assigned to it and that you have at least 'Editor' permissions on it.
 
     gcloud --project [PROJECT_ID] services enable \
+        artifactregistry.googleapis.com \
         cloudbuild.googleapis.com \
         cloudresourcemanager.googleapis.com \
-        containerregistry.googleapis.com \
         deploymentmanager.googleapis.com \
         redis.googleapis.com \
         run.googleapis.com \

--- a/contrib/gcp/portier.jinja
+++ b/contrib/gcp/portier.jinja
@@ -220,8 +220,10 @@ resources:
 {%- if "resolver" in properties %}
             - name: BROKER_VERIFY_WITH_RESOLVER
               value: {{ properties["resolver"] }}
+{%- if "public_ip" in properties %}
             - name: BROKER_VERIFY_PUBLIC_IP
-              value: "true"
+              value: "{{ properties["public_ip"] }}"
+{%- endif %}
 {%- endif %}
             resources:
               limits:

--- a/contrib/gcp/portier.jinja
+++ b/contrib/gcp/portier.jinja
@@ -11,6 +11,17 @@ resources:
         value: >
           $.concat("Bearer ", $.googleOauth2AccessToken())
 
+- name: {{ env["deployment"] }}-typeprovider-artifactregistry
+  type: deploymentmanager.v2beta.typeProvider
+  properties:
+    descriptorUrl: https://artifactregistry.googleapis.com/$discovery/rest?version=v1
+    options:
+      inputMappings:
+      - fieldName: Authorization
+        location: HEADER
+        value: >
+          $.concat("Bearer ", $.googleOauth2AccessToken())
+
 - name: {{ env["deployment"] }}-typeprovider-cloudbuild
   type: deploymentmanager.v2beta.typeProvider
   properties:
@@ -57,6 +68,15 @@ resources:
         value: >
           $.concat("Bearer ", $.googleOauth2AccessToken())
 
+- name: {{ env['deployment'] }}-repository
+  type: {{ env["project"] }}/{{ env["deployment"] }}-typeprovider-artifactregistry:projects.locations.repositories
+  metadata:
+    dependsOn:
+    - {{ env["deployment"] }}-typeprovider-artifactregistry
+  properties:
+    parent: projects/{{ env["project"] }}/locations/{{ properties["region"] }}
+    repositoryId: env["deployment"]
+
 - name: {{ env["deployment"] }}-sourcerepo
   type: {{ env["project"] }}/{{ env["deployment"] }}-typeprovider-sourcerepo:projects.repos
   metadata:
@@ -72,6 +92,7 @@ resources:
     dependsOn:
     - {{ env["deployment"] }}-typeprovider-cloudbuild
     - {{ env["deployment"] }}-sourcerepo
+    - {{ env['deployment'] }}-repository
   properties:
     projectId: {{ env["project"] }}
     name: {{ env["deployment"] }}
@@ -81,13 +102,13 @@ resources:
       tagName: ^prod$
     build:
       images:
-      - gcr.io/$PROJECT_ID/$REPO_NAME:$TAG_NAME
+      - {{ properties["region"] }}-docker.pkg.dev/$PROJECT_ID/$REPO_NAME/$REPO_NAME:$TAG_NAME
       steps:
       - name: gcr.io/cloud-builders/docker
         args:
         - build
         - -t
-        - gcr.io/$PROJECT_ID/$REPO_NAME:$TAG_NAME
+        - {{ properties["region"] }}-docker.pkg.dev/$PROJECT_ID/$REPO_NAME/$REPO_NAME:$TAG_NAME
 {%- if "data_url" in properties %}
         - --build-arg=data_url={{ properties["data_url"] }}
 {%- endif %}
@@ -169,7 +190,7 @@ resources:
           serviceAccountName: $(ref.{{ env["deployment"] }}-serviceaccount.email)
           timeoutSeconds: 30
           containers:
-          - image: gcr.io/{{ env["project"] }}/{{ env["deployment"] }}:prod
+          - image: {{ properties["region"] }}-docker.pkg.dev/{{ env["project"] }}/{{ env["deployment"] }}/{{ env["deployment"] }}:prod
             ports:
             - name: http1
               containerPort: 3333

--- a/contrib/gcp/portier.jinja.schema
+++ b/contrib/gcp/portier.jinja.schema
@@ -72,8 +72,14 @@ properties:
   resolver:
     type: string
     description: >
-      Used to populate config.toml:verify_with_resolver (also sets verify_public_ip to true)
+      Used to populate config.toml:verify_with_resolver
     default: 169.254.169.254:53
+
+  public_ip:
+    type: boolean
+    description: >
+      Used to populate config.toml:verify_public_ip (only used when 'resolver' is set)
+    default: true
 
   from_name:
     type: string


### PR DESCRIPTION
Another week, another product in the Google Graveyard, this time it is Container Registry. One of the commits in this PR migrates to Artifact Registry...probably will be here again next week as that is set to be phased out too...</rant> :-/

The other commit is in response to O365 sucking in other ways too, turns out their name servers are unreliable and *often* fail to return A/AAAA records so we make `public_ip` configurable in the deployment template; correcting what it always should have been.
