### PR TITLE
CORS support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,11 @@
 FROM rust:1-alpine AS build
 RUN apk add --no-cache build-base
 WORKDIR /build
+#### BEGIN faster development https://stackoverflow.com/a/58474618 ####
+COPY Cargo.toml Cargo.lock ./
+RUN echo 'fn main() {}' > dummy.rs && sed -i -e 's#src/main.rs#dummy.rs#' Cargo.toml
+#### END faster development ####
+RUN cargo build --release --locked
 COPY . .
 RUN cargo build --release --locked
 

--- a/contrib/gcp/portier.jinja
+++ b/contrib/gcp/portier.jinja
@@ -109,6 +109,8 @@ resources:
         - build
         - -t
         - {{ properties["region"] }}-docker.pkg.dev/$PROJECT_ID/$REPO_NAME/$REPO_NAME:$TAG_NAME
+        - --cache-from
+        - {{ properties["region"] }}-docker.pkg.dev/$PROJECT_ID/$REPO_NAME/$REPO_NAME:$TAG_NAME
 {%- if "data_url" in properties %}
         - --build-arg=data_url={{ properties["data_url"] }}
 {%- endif %}

--- a/src/router.rs
+++ b/src/router.rs
@@ -33,6 +33,9 @@ pub async fn router(ctx: &mut Context) -> HandlerResult {
         // Lastly, fall back to trying to serve static files out of ./res/
         (&(Method::GET | Method::HEAD), _) => handlers::pages::static_(ctx).await,
 
+        // Needed for CORS
+        (&Method::OPTIONS, _) => Ok(empty_response(StatusCode::NO_CONTENT)),
+
         _ => Ok(empty_response(StatusCode::BAD_REQUEST)),
     }
 }


### PR DESCRIPTION
This PR adds CORS headers depending on the value of `allowed_origins`.

Excuse the awful Rust code, I am not a Rust programmer, but this seems to work for me.

Can this be reviewed and considered by someone who knows what they are doing? :)

The 'development improvement' commit might be interesting to you, spares me having to install Rust directly on my workstation and allows you to skip the download and building of the dependencies on re-builds.

Resolves #198