### PR TITLE
fix CORS support edge case

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@
 FROM rust:1-alpine AS build
 RUN apk add --no-cache build-base
 WORKDIR /build
-RUN cargo build --release --locked
 COPY . .
 # To create a debug build instead, add: --build-arg cargo_flags=""
 ARG cargo_flags="--release --locked"

--- a/contrib/gcp/portier.jinja
+++ b/contrib/gcp/portier.jinja
@@ -144,7 +144,7 @@ resources:
     parent: projects/{{ env["project"] }}/locations/{{ properties["region"] }}
     instanceId: {{ env["deployment"] }}
     tier: STANDARD_HA
-    redisVersion: REDIS_5_0
+    redisVersion: REDIS_7_2
     memorySizeGb: 1
     authEnabled: true
 

--- a/contrib/gcp/portier.jinja
+++ b/contrib/gcp/portier.jinja
@@ -105,6 +105,8 @@ resources:
       - {{ properties["region"] }}-docker.pkg.dev/$PROJECT_ID/$REPO_NAME/$REPO_NAME:$TAG_NAME
       steps:
       - name: gcr.io/cloud-builders/docker
+        env:
+        - DOCKER_BUILDKIT=1
         args:
         - build
         - -t

--- a/contrib/gcp/portier.jinja
+++ b/contrib/gcp/portier.jinja
@@ -248,6 +248,8 @@ resources:
               value: "{{ properties["public_ip"] }}"
 {%- endif %}
 {%- endif %}
+            - name: BROKER_CORS_TTL
+              value: "{{ properties["cors_ttl"] }}"
             resources:
               limits:
                 cpu: 1000m

--- a/contrib/gcp/portier.jinja.schema
+++ b/contrib/gcp/portier.jinja.schema
@@ -113,6 +113,12 @@ properties:
     description: >
       Password for SMTP server
 
+  cors_ttl:
+    type: integer
+    description: >
+      Setting to a non-zero value will add CORS headers to the response and set the Access-Control-Max-Age header to the value provided here
+    default: 0
+
   instances_min:
     type: integer
     description: >


### PR DESCRIPTION
Missing functionality from the PR #996, where when `allowed_origins` is unset, the CORS headers should be sent too.

Also a commit to fix the Dockerfile (cannot build when you got no source code); looks like just a line missed being trimmed.