### PR TITLE
allow Content-Security-Policy response header to be customized

### DIFF
--- a/config.toml.dist
+++ b/config.toml.dist
@@ -210,6 +210,11 @@ allowed_domains_only = false
 
 #cors_ttl = 0
 
+# EXPERIMENTAL. If set, the value of this settings controls the value of the
+# `Content-Security-Policy` response header.
+
+#csp = "..."
+
 ################################################################
 # Advanced settings
 

--- a/contrib/gcp/portier.jinja
+++ b/contrib/gcp/portier.jinja
@@ -250,8 +250,14 @@ resources:
               value: "{{ properties["public_ip"] }}"
 {%- endif %}
 {%- endif %}
+{%- if "cors_ttl" in properties %}
             - name: BROKER_CORS_TTL
               value: "{{ properties["cors_ttl"] }}"
+{%- endif %}
+{%- if "csp" in properties %}
+            - name: BROKER_CSP
+              value: "{{ properties["csp"] }}"
+{%- endif %}
             resources:
               limits:
                 cpu: 1000m

--- a/contrib/gcp/portier.jinja.schema
+++ b/contrib/gcp/portier.jinja.schema
@@ -117,7 +117,11 @@ properties:
     type: integer
     description: >
       Setting to a non-zero value will add CORS headers to the response and set the Access-Control-Max-Age header to the value provided here
-    default: 0
+
+  csp:
+    type: string
+    description: >
+      Setting to a non-zero value will add CORS headers to the response and set the Access-Control-Max-Age header to the value provided here
 
   instances_min:
     type: integer

--- a/src/config/env.rs
+++ b/src/config/env.rs
@@ -23,6 +23,7 @@ pub struct EnvConfig {
 
     allowed_origins: Option<StringList>,
     cors_ttl: Option<u64>,
+    csp: Option<String>,
     #[serde(default)]
     allowed_domains: StringList,
     #[serde(default)]
@@ -145,6 +146,9 @@ impl EnvConfig {
         }
         if let Some(val) = parsed.cors_ttl {
             builder.cors_ttl = Duration::from_secs(val);
+        }
+        if let Some(val) = parsed.csp {
+            builder.csp = Some(val);
         }
         for (source, res) in parsed.allowed_domains.iter_values() {
             let data = match res {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -71,6 +71,7 @@ pub struct Config {
     pub trusted_proxies: Vec<IpNetwork>,
     pub allowed_origins: Option<Vec<String>>,
     pub cors_ttl: Duration,
+    pub csp: Option<String>,
     pub domain_validator: DomainValidator,
 
     pub static_ttl: Duration,
@@ -392,6 +393,7 @@ pub struct ConfigBuilder {
     pub trusted_proxies: Vec<IpNetwork>,
     pub allowed_origins: Option<Vec<String>>,
     pub cors_ttl: Duration,
+    pub csp: Option<String>,
     pub domain_validator: DomainValidator,
     pub data_dir: String,
 
@@ -459,6 +461,7 @@ impl ConfigBuilder {
                 .collect(),
             allowed_origins: None,
             cors_ttl: Duration::ZERO,
+            csp: None,
             domain_validator: DomainValidator::new(),
             data_dir: String::new(),
 
@@ -669,6 +672,7 @@ impl ConfigBuilder {
             trusted_proxies: self.trusted_proxies,
             allowed_origins: self.allowed_origins,
             cors_ttl: self.cors_ttl,
+            csp: self.csp,
             domain_validator: self.domain_validator,
 
             static_ttl: self.static_ttl,

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -22,6 +22,7 @@ pub struct TomlConfig {
 
     allowed_origins: Option<StringList>,
     cors_ttl: Option<u64>,
+    csp: Option<String>,
     #[serde(default)]
     allowed_domains: StringList,
     #[serde(default)]
@@ -281,6 +282,9 @@ impl TomlConfig {
         }
         if let Some(val) = parsed.cors_ttl {
             builder.cors_ttl = Duration::from_secs(val);
+        }
+        if let Some(val) = parsed.csp {
+            builder.csp = Some(val);
         }
         for (source, res) in parsed.allowed_domains.iter_values() {
             let data = match res {


### PR DESCRIPTION
This PR allows the user to optionally customise the Content-Security-Policy header to loosen the restrictions currently in place, for example to set `font-src: 'self'`.