### PR TITLE
for CORS include 'vary: origin' to avoid CORS errors between two RPs

### DIFF
--- a/src/web.rs
+++ b/src/web.rs
@@ -562,6 +562,10 @@ fn set_cors_headers<B>(ctx: &Context, res: &mut hyper::Response<B>) {
             hyper::header::ACCESS_CONTROL_MAX_AGE,
             cors_ttl.as_secs().to_string(),
         );
+        // two RP's using the same instance would re-use the cached CORS
+        // response for the other site and result in a CORS access error
+        // so we use this to tell the browser to cache partition by origin
+        res.header(hyper::header::VARY, "origin".to_owned());
     }
 }
 


### PR DESCRIPTION
If you have multiple RPs using the same Portier instance via a SPA then the caching on `/.well-known/openid-configuration` (and others) causes problems as within the period another site will see CORS headers allowing the other site and not its-self.

To resolve this we needs `vary: origin` to be included to instruct the browser cache to partition by `origin`.