### PR TITLE
Allow Redis TLS

### DIFF
--- a/docs/storage/redis.md
+++ b/docs/storage/redis.md
@@ -31,10 +31,10 @@ variables:
 
 ## Security
 
-It is strongly recommended to protect your Redis server at the network level.
-You should take as much care as possible to only allow the broker to connect to
-Redis. Ideally, you'd also ensure no eavesdropping is possible on the
-connections (but this can be difficult in the cloud).
+It is strongly recommended to secure your connection to the Redis server.
+Either ensure the connection uses a secure network, or use TLS (using
+`rediss://` URLs). You should take as much care as possible to only allow the
+broker to connect to Redis.
 
 Notable DON'Ts:
 

--- a/src/agents/store/redis.rs
+++ b/src/agents/store/redis.rs
@@ -76,10 +76,12 @@ impl RedisStore {
         fetcher: Addr<FetchAgent>,
         rng: SecureRandom,
     ) -> RedisResult<Self> {
-        if url.starts_with("http://") {
-            url = url.replace("http://", "redis://");
-        } else if !url.starts_with("redis://") {
+        if !url.contains("://") {
+            // Fixes up standalone IPs or hostnames.
             url = format!("redis://{}", &url);
+        } else if url.starts_with("http") {
+            // Handles both HTTP and HTTPS URLs provided by some provisioning systems.
+            url = format!("redis{}", &url[4..]);
         }
         let id = rng.generate_async(16).await.into();
         let mut info = url.as_str().into_connection_info()?;


### PR DESCRIPTION
Fixes #351.

Needs testing. Probably need a way to pin the server certificate.

This also allows connecting over Unix sockets, though for local usage, may as well use the existing SQLite backend.

The redis lib also accepts `valkey://` URLs, which is also a small bonus.